### PR TITLE
Bump @prismicio/client from 5.1.0 to 6.7.1

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -8,8 +8,8 @@ const Header = () => {
         <Link href='/'>
           <a className='ident'>
             <picture>
-              <source srcSet='/logo-small.svg 100w' media='(max-width: 479px)' />
-              <source srcSet='/logo.svg 100w' media='(min-width: 480px)' />
+              <source srcSet='/logo-small.svg 100w' media='(max-width: 549px)' />
+              <source srcSet='/logo.svg 100w' media='(min-width: 550px)' />
               <img src='/logo.svg' className='ident__svg' alt='Sketchplanations' />
             </picture>
           </a>
@@ -25,6 +25,13 @@ const Header = () => {
 
         .ident {
           @apply block;
+          width: 27px;
+        }
+
+        @media (min-width: 550px) {
+          .ident {
+            width: 205px;
+          }
         }
 
         @screen dark {

--- a/components/Sketchplanation.js
+++ b/components/Sketchplanation.js
@@ -146,8 +146,8 @@ const Sketchplanation = ({ sketchplanation, fullPost = false, hideContent = fals
       </div>
       <style jsx>{`
         .root {
+          @apply w-full px-0;
           max-width: 600px;
-          @apply px-0;
         }
 
         @screen sm {

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,16 +1,17 @@
 import { either, isEmpty, isNil, complement } from 'ramda'
+import { Predicates } from '@prismicio/client'
 
-import { Predicates, client } from 'services/prismic'
+import { client } from 'services/prismic'
 
 const defaultPageTitle = 'Sketchplanations - A weekly explanation in a sketch'
 
 const search = async (documentType, query) => {
   if (!query || query === '') return []
 
-  const { results } = await client.query(
-    [Predicates.at('document.type', documentType), Predicates.fulltext('document', query)],
-    { pageSize: 100 }
-  )
+  const { results } = await client.get({
+    predicates: [Predicates.at('document.type', documentType), Predicates.fulltext('document', query)],
+    pageSize: 100,
+  })
 
   return results
 }
@@ -18,25 +19,6 @@ const search = async (documentType, query) => {
 export const searchSketchplanations = async (query) => await search('sketchplanation', query)
 
 export const searchTags = async (query) => await search('tag', query)
-
-export const queryAll = async (predicates, options = {}) => {
-  let page = 1
-  let hasNextPage = true
-  const documents = []
-
-  do {
-    let response = await client.query(predicates, {
-      ...options,
-      pageSize: 100,
-      page,
-    })
-    documents.push(...response.results)
-    page++
-    hasNextPage = page <= response.total_pages
-  } while (hasNextPage)
-
-  return documents
-}
 
 export const pageTitle = (title) => {
   if (!title) return defaultPageTitle

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node utils/generate_sitemap.js && node utils/generate_rss.js && node utils/generate_uids_data.js",
     "dev": "next dev",
-    "build": "next build && node utils/generate_sitemap.js && node utils/generate_rss.js && node utils/generate_uids_data.js",
+    "prebuild": "node utils/generate_sitemap.js && node utils/generate_rss.js && node utils/generate_uids_data.js",
+    "build": "next build",
     "start": "next start"
   },
   "dependencies": {
-    "@prismicio/client": "^5.1.0",
+    "@prismicio/client": "^6.7.1",
     "@sentry/react": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "@stripe/react-stripe-js": "^1.4.0",

--- a/pages/archive.js
+++ b/pages/archive.js
@@ -2,8 +2,7 @@ import Gallery from 'react-photo-gallery'
 import Imgix from 'react-imgix'
 import Link from 'next/link'
 
-import { Predicates } from 'services/prismic'
-import { queryAll } from 'helpers'
+import { client } from 'services/prismic'
 
 const Archive = ({ sketchplanations }) => {
   const images = sketchplanations.map(
@@ -79,8 +78,11 @@ const Archive = ({ sketchplanations }) => {
 }
 
 export async function getStaticProps() {
-  const sketchplanations = await queryAll(Predicates.at('document.type', 'sketchplanation'), {
-    orderings: '[my.sketchplanation.published_at desc]',
+  const sketchplanations = await client.getAllByType('sketchplanation', {
+    orderings: {
+      field: 'my.sketchplanation.published_at',
+      direction: 'desc',
+    },
   })
 
   return { props: { sketchplanations } }

--- a/pages/explore.js
+++ b/pages/explore.js
@@ -2,14 +2,15 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import Gallery from 'react-photo-gallery'
 import Link from 'next/link'
+import { Predicates } from '@prismicio/client'
 
-import { Predicates } from 'services/prismic'
-import { queryAll, isBlank, searchSketchplanations, searchTags, isPresent } from 'helpers'
+import { isBlank, searchSketchplanations, searchTags, isPresent } from 'helpers'
 import useDebouncedValue from 'hooks/useDebouncedValue'
 import SearchForm from 'components/SearchForm'
 import SketchplanationGalleryPhoto from 'components/SketchplanationGalleryPhoto'
 import Tags from 'components/Tags'
 import useGalleryPhotos from 'hooks/useGalleryPhotos'
+import { client } from 'services/prismic'
 
 const Explore = ({ initialSketchplanations }) => {
   const router = useRouter()
@@ -130,8 +131,11 @@ const Explore = ({ initialSketchplanations }) => {
 }
 
 export async function getStaticProps() {
-  const initialSketchplanations = await queryAll(Predicates.at('document.type', 'sketchplanation'), {
-    orderings: '[my.sketchplanation.published_at desc]',
+  const initialSketchplanations = await client.getAllByType('sketchplanation', {
+    orderings: {
+      field: 'my.sketchplanation.published_at',
+      direction: 'desc',
+    },
   })
 
   return { props: { initialSketchplanations: initialSketchplanations.slice(0, 20) } }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import React, { useState } from 'react'
 
-import { client, Predicates } from 'services/prismic'
+import { client } from 'services/prismic'
 
 const Sketchplanation = dynamic(() => import('../components/Sketchplanation'))
 
@@ -12,8 +12,11 @@ const Home = ({ sketchplanations }) => {
   const [results, setResults] = useState(sketchplanations.results)
 
   const fetchMore = async () => {
-    const moreSketchplanations = await client.query(Predicates.at('document.type', 'sketchplanation'), {
-      orderings: '[my.sketchplanation.published_at desc]',
+    const moreSketchplanations = await client.getByType('sketchplanation', {
+      orderings: {
+        field: 'my.sketchplanation.published_at',
+        direction: 'desc',
+      },
       page,
       pageSize: 5,
     })
@@ -83,8 +86,11 @@ const Home = ({ sketchplanations }) => {
 }
 
 Home.getInitialProps = async () => {
-  const sketchplanations = await client.query(Predicates.at('document.type', 'sketchplanation'), {
-    orderings: '[my.sketchplanation.published_at desc]',
+  const sketchplanations = await client.getByType('sketchplanation', {
+    orderings: {
+      field: 'my.sketchplanation.published_at',
+      direction: 'desc',
+    },
     pageSize: 4,
   })
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,7 +18,7 @@ const Home = ({ sketchplanations }) => {
         direction: 'desc',
       },
       page,
-      pageSize: 5,
+      pageSize: 4,
     })
     setResults([...results, ...moreSketchplanations.results])
     setPage(page + 1)

--- a/pages/tags.js
+++ b/pages/tags.js
@@ -1,9 +1,8 @@
 import { sort } from 'fast-sort'
 import Link from 'next/link'
 import useCookie from 'react-use-cookie'
-
-import { Predicates } from 'services/prismic'
-import { queryAll } from 'helpers'
+import { Predicates } from '@prismicio/client'
+import { client } from 'services/prismic'
 
 const countOccurrences = (arr, val) => arr.reduce((a, v) => (v === val ? a + 1 : a), 0)
 
@@ -101,12 +100,17 @@ const Tags = ({ tagsByName, tagsByCount }) => {
 }
 
 export async function getStaticProps() {
-  const sketchplanations = await queryAll(Predicates.at('document.type', 'sketchplanation'), {
-    orderings: '[my.sketchplanation.published_at desc]',
+  const sketchplanations = await client.getAllByType('sketchplanation', {
+    orderings: {
+      field: 'my.sketchplanation.published_at',
+      direction: 'desc',
+    },
   })
 
-  const tags = await queryAll(Predicates.at('document.type', 'tag'), {
-    orderings: '[my.tag.identifier]',
+  const tags = await client.getAllByType('tag', {
+    orderings: {
+      field: 'my.tag.identifier',
+    },
   })
 
   const tagsFromSketchplanations = sketchplanations

--- a/services/prismic.js
+++ b/services/prismic.js
@@ -1,4 +1,4 @@
-import Prismic from '@prismicio/client'
+import { createClient } from '@prismicio/client'
 
 // -- Prismic API endpoint
 // Determines which repository to query and fetch data from
@@ -40,6 +40,4 @@ export const hrefResolver = (doc) => {
 // -- Client method to query Prismic
 // Connects to the given repository to facilitate data queries
 // export const client = Prismic.client(apiEndpoint, { accessToken })
-export const client = Prismic.client(apiEndpoint)
-
-export const Predicates = Prismic.Predicates
+export const client = createClient(apiEndpoint)

--- a/utils/generate_rss.js
+++ b/utils/generate_rss.js
@@ -1,8 +1,7 @@
 const { create } = require('xmlbuilder2')
 const fs = require('fs')
-const Prismic = require('@prismicio/client')
 const PrismicDOM = require('prismic-dom')
-const { queryAll } = require('./helpers')
+const { client } = require('./helpers')
 
 const pubDate = (date) => {
   date = new Date(date)
@@ -16,7 +15,7 @@ const pubDate = (date) => {
 }
 
 async function generateRSS() {
-  const sketchplanations = await queryAll(Prismic.Predicates.at('document.type', 'sketchplanation'), {
+  const sketchplanations = await client.getAllByType('sketchplanation', {
     fetch: [
       'sketchplanation.uid',
       'sketchplanation.title',
@@ -24,7 +23,10 @@ async function generateRSS() {
       'sketchplanation.body',
       'sketchplanation.published_at',
     ],
-    orderings: '[my.sketchplanation.published_at desc]',
+    orderings: {
+      field: 'my.sketchplanation.published_at',
+      direction: 'desc',
+    },
   })
 
   const items = sketchplanations.map(

--- a/utils/generate_sitemap.js
+++ b/utils/generate_sitemap.js
@@ -1,18 +1,21 @@
 const { create } = require('xmlbuilder2')
 const fs = require('fs')
 const globby = require('globby')
-const Prismic = require('@prismicio/client')
-const { queryAll } = require('./helpers')
+const { client } = require('./helpers')
 
 async function generateSitemap() {
-  const sketchplanations = await queryAll(Prismic.Predicates.at('document.type', 'sketchplanation'), {
+  const sketchplanations = await client.getAllByType('sketchplanation', {
     fetch: 'sketchplanation.uid',
-    orderings: '[document.last_publication_date]',
+    orderings: {
+      field: 'document.last_publication_date',
+    },
   })
 
-  const tags = await queryAll(Prismic.Predicates.at('document.type', 'tag'), {
+  const tags = await client.getAllByType('tag', {
     fetch: 'tag.identifier',
-    orderings: '[my.tag.identifier]',
+    orderings: {
+      field: 'my.tag.identifier',
+    },
   })
 
   const lastSketchPubDate = new Date(sketchplanations[sketchplanations.length - 1].last_publication_date)

--- a/utils/generate_uids_data.js
+++ b/utils/generate_uids_data.js
@@ -1,9 +1,8 @@
 const fs = require('fs')
-const Prismic = require('@prismicio/client')
-const { queryAll } = require('./helpers')
+const { client } = require('./helpers')
 
 async function generateUidsData() {
-  const sketchplanations = await queryAll(Prismic.Predicates.at('document.type', 'sketchplanation'), {
+  const sketchplanations = await client.getAllByType('sketchplanation', {
     fetch: ['sketchplanation.uid'],
   })
 

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,23 +1,5 @@
-const Prismic = require('@prismicio/client')
+const fetch = require('node-fetch')
+const { createClient } = require('@prismicio/client')
 const apiEndpoint = 'https://sketchplanations.prismic.io/api/v2'
 
-exports.queryAll = async (predicates, options = {}) => {
-  let page = 1
-  let hasNextPage = true
-  const documents = []
-
-  const client = Prismic.client(apiEndpoint)
-
-  do {
-    let response = await client.query(predicates, {
-      ...options,
-      pageSize: 100,
-      page,
-    })
-    documents.push(...response.results)
-    page++
-    hasNextPage = page <= response.total_pages
-  } while (hasNextPage)
-
-  return documents
-}
+exports.client = createClient(apiEndpoint, { fetch })

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,22 +213,45 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.1.tgz#728ecd95ab207aab8a9a4e421f0422db329232be"
   integrity sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw==
 
-"@prismicio/client@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-5.1.0.tgz#f236d7fca09535d61e599872e7c38afda62b8b3c"
-  integrity sha512-LCb+arVVxJOoPM+8qfLCC/Dqse7mh+Q1k3oo5W5Uzu7vVO+vtc7CUYHxgCDkvekakYHc9407kwWu65ErZw+CPQ==
+"@prismicio/client@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-6.7.1.tgz#2c4a514a6e3865008716e3d2cbabaa0cb919090b"
+  integrity sha512-XIFSZtLjxnpQavu2R7jIqmnFvUqRRzHwjXHt/fb0N550rFLQM4tnwDuSR3VY6k/TG+M5zvH+PHJuXGNnv73qUQ==
   dependencies:
-    cross-fetch "^3.0.6"
+    "@prismicio/helpers" "^2.3.3"
+    "@prismicio/types" "^0.2.3"
 
 "@prismicio/helpers@^1.0.4":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-1.0.5.tgz#2be60a1b44e6c33d7918fa74fe67648dc8af0c15"
   integrity sha512-TPpuAFHNxlCTrEihHnRKcq6zc0oZV0sfz5/iHoSpl5vorwPbwZWiF88JGeflNdefW4A69b5A3x3mfptKPdpoxg==
 
+"@prismicio/helpers@^2.3.3":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-2.3.5.tgz#facb441c35d0ce19996350e1cc9c6f7fc676b6ee"
+  integrity sha512-lL9TQG+GKtOATvLOlTFoaDfEZOgrNXHRuD+TxCSwLPKRBtYVs6zBoU6SkkcISm/DCe8PwGD0zo44zDdPtFJuBA==
+  dependencies:
+    "@prismicio/richtext" "^2.1.1"
+    "@prismicio/types" "^0.2.3"
+    escape-html "^1.0.3"
+    imgix-url-builder "^0.0.3"
+
 "@prismicio/richtext@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@prismicio/richtext/-/richtext-1.1.0.tgz#c8769c3d953ae42854a2aba951e3b2121682b8c7"
   integrity sha512-925JuFiZiIkwu9jmlR9O/U8xCSZk/Y6BQDXKpavoVsKo+n90ml1hGdtWkglIupX+ITQO1ZINyDgUgiY1oG9dsA==
+
+"@prismicio/richtext@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@prismicio/richtext/-/richtext-2.1.1.tgz#45b76b0bcfe40a5465c14d7d458e3354f6510068"
+  integrity sha512-/99JR2NUU2WV0025eAIqjd9OnF4ITaM57SVuhLc1XBUgnJe0HZrC9f24YKVW43jFR5HYTJtLgz01WjEddymqmA==
+  dependencies:
+    "@prismicio/types" "^0.2.0"
+
+"@prismicio/types@^0.2.0", "@prismicio/types@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@prismicio/types/-/types-0.2.3.tgz#9f4c5bce441e1d59242f1795acb77f7a583cad99"
+  integrity sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw==
 
 "@restart/hooks@^0.3.26":
   version "0.3.27"
@@ -1243,13 +1266,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
-  dependencies:
-    node-fetch "2.6.1"
-
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1699,7 +1715,7 @@ escape-goat@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-html@1.0.3:
+escape-html@1.0.3, escape-html@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -2421,6 +2437,11 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+imgix-url-builder@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz#9f386de64cdd1363d352a7f6313fd7dacd8fb282"
+  integrity sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
- [x] Bump @prismicio/client from 5.1.0 to 6.7.1. See the [benefits of upgrading](https://prismic.io/docs/prismic-client-v6-migration-guide#benefits-of-upgrading)
- [x] Replace custom `queryAll` helpers with Prismic's new `getAll*` methods
- [x] Fix invisible logo in Firefox
- [x] Update breakpoint for small-screen logo
- [x] Fix Sketchplanation title underlining when changing pages