### PR TITLE
Use next/font for self-hosted Google fonts

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { Elements } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 import 'lazysizes'
 import 'lazysizes/plugins/attrchange/ls.attrchange'
+import { Inter } from 'next/font/google'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import TagManager from 'react-gtm-module'
@@ -13,6 +14,8 @@ import Header from 'components/Header'
 import SubscribeModal from 'components/SubscribeModal'
 import { getCookie, pageTitle, setCookie } from 'helpers'
 import useScrollPercentage from 'hooks/useScrollPercentage'
+
+const inter = Inter({ subsets: ['latin'] })
 
 const polyfillDownloadAttr = () => {
   const downloadAttributeSupport = 'download' in document.createElement('a')
@@ -106,7 +109,7 @@ const Sketchplanations = ({ Component, pageProps }) => {
         <meta name='viewport' content='width = device-width, initial-scale = 1, minimum-scale = 1' />
       </Head>
       <Header />
-      <div ref={ref}>
+      <div ref={ref} className={inter.className}>
         <Component {...pageProps} />
       </div>
       {subscribeModalEnabled && (

--- a/pages/tags/[tag].js
+++ b/pages/tags/[tag].js
@@ -2,10 +2,10 @@ import { Predicates } from '@prismicio/client'
 import { useRouter } from 'next/router'
 
 import { TextHeader } from 'components'
+import SketchplanationsGrid from 'components/SketchplanationsGrid'
 import { client } from 'services/prismic'
 
 import styles from './[tag].module.css'
-import SketchplanationsGrid from 'components/SketchplanationsGrid'
 
 const Tag = ({ tag, sketchplanations }) => {
   const router = useRouter()


### PR DESCRIPTION
> `next/font` includes built-in automatic self-hosting for any font file. This means you can optimally load web fonts with zero layout shift, thanks to the underlying CSS `size-adjust` property used.
> 
> This new font system also allows you to conveniently use all Google Fonts with performance and privacy in mind. CSS and font files are downloaded at build time and self-hosted with the rest of your static assets. **No requests are sent to Google by the browser.**

https://nextjs.org/docs/basic-features/font-optimization