### PR TITLE
Made tags disappear and subscribe stay on mobile nav

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -20,23 +20,23 @@ const Navigation = () => {
 
   return (
     <nav className={styles.root}>
-      <Link href='/tags' className={styles.item}>
-        <RoughNotation show={isSelected('/tags')} {...roughNotiationProps}>
-          Tags
-        </RoughNotation>
-      </Link>
+      <span className={styles['gt-sm-screen']}>
+        <Link href='/tags' className={styles.item}>
+          <RoughNotation show={isSelected('/tags')} {...roughNotiationProps}>
+            Tags
+          </RoughNotation>
+        </Link>
+      </span>
       <Link href='/explore' className={styles.item}>
         <RoughNotation show={isSelected('/explore')} {...roughNotiationProps}>
           Explore
         </RoughNotation>
       </Link>
-      <span className={styles['gt-sm-screen']}>
-        <Link href='/subscribe' className={styles.item}>
-          <RoughNotation show={isSelected('/subscribe')} {...roughNotiationProps}>
-            Subscribe
-          </RoughNotation>
-        </Link>
-      </span>
+      <Link href='/subscribe' className={styles.item}>
+        <RoughNotation show={isSelected('/subscribe')} {...roughNotiationProps}>
+          Subscribe
+        </RoughNotation>
+      </Link>
       <Link href='/about' className={styles.item}>
         <RoughNotation show={isSelected('/about')} {...roughNotiationProps}>
           About


### PR DESCRIPTION
Tags was staying on the mobile nav and someone reported that they didn't even realise it was a newsletter when they visited on mobile. This change makes 'subscribe' stay on mobile navs and 'tags' disappear.

![image](https://github.com/jonohey/sketchplanations/assets/1498914/55e95831-7cf2-4649-be0d-1b018097d741)
