### PR TITLE
Added book to nav in place of tags

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -20,13 +20,11 @@ const Navigation = () => {
 
   return (
     <nav className={styles.root}>
-      <span className={styles['gt-sm-screen']}>
-        <Link href='/tags' className={styles.item}>
-          <RoughNotation show={isSelected('/tags')} {...roughNotiationProps}>
-            Tags
-          </RoughNotation>
-        </Link>
-      </span>
+      <Link href='/big-ideas-little-pictures' className={styles.item}>
+        <RoughNotation show={isSelected('/big-ideas-little-pictures')} {...roughNotiationProps}>
+          Book!
+        </RoughNotation>
+      </Link>
       <Link href='/explore' className={styles.item}>
         <RoughNotation show={isSelected('/explore')} {...roughNotiationProps}>
           Explore
@@ -42,21 +40,23 @@ const Navigation = () => {
           About
         </RoughNotation>
       </Link>
-      <a
-        href='https://www.redbubble.com/people/sketchplanator/shop?asc=u'
-        target='_blank'
-        rel='noreferrer'
-        className={styles.item}
-      >
-        Shop
-        <svg xmlns='http://www.w3.org/2000/svg' width='10' height='12' viewBox='0 0 13 15'>
-          <path
-            fill='currentColor'
-            fillRule='nonzero'
-            d='M11.56.316c.026 0 .052.002.077.003.584.026.987.261.9.825-.011.078-.098.24-.227.446l-.173.265-.199.292-.428.599-.64.853C9.756 5.183 8.813 6.95 8.02 9.168a.5.5 0 1 1-.941-.336c.823-2.308 1.808-4.153 2.972-5.808.134-.19.267-.374.407-.561l.275-.362-.335.153c-.34.159-.67.317-.99.474l-.624.315c-.508.262-.987.524-1.438.784l-.526.311c-.256.156-.502.311-.738.466l-.459.31-.432.308C1.076 8.246.795 11.107 3.223 13.645a.5.5 0 1 1-.722.691C-.846 10.838.22 6.78 7.114 2.827l.588-.329c.2-.11.406-.219.615-.328l.642-.328c.263-.131.533-.262.81-.393l-1.684.166-1.171.104-.664.054-1.357.1c-.921.062-1.877.117-2.89.164a.5.5 0 1 1-.046-1C2.962.992 3.91.938 4.825.876L6.17.776 6.83.723 7.992.619l2.521-.246.442-.036.236-.014.198-.007h.17Z'
-          />
-        </svg>
-      </a>
+      <span className={styles['gt-sm-screen']}>
+        <a
+          href='https://www.redbubble.com/people/sketchplanator/shop?asc=u'
+          target='_blank'
+          rel='noreferrer'
+          className={styles.item}
+        >
+          Shop
+          <svg xmlns='http://www.w3.org/2000/svg' width='10' height='12' viewBox='0 0 13 15'>
+            <path
+              fill='currentColor'
+              fillRule='nonzero'
+              d='M11.56.316c.026 0 .052.002.077.003.584.026.987.261.9.825-.011.078-.098.24-.227.446l-.173.265-.199.292-.428.599-.64.853C9.756 5.183 8.813 6.95 8.02 9.168a.5.5 0 1 1-.941-.336c.823-2.308 1.808-4.153 2.972-5.808.134-.19.267-.374.407-.561l.275-.362-.335.153c-.34.159-.67.317-.99.474l-.624.315c-.508.262-.987.524-1.438.784l-.526.311c-.256.156-.502.311-.738.466l-.459.31-.432.308C1.076 8.246.795 11.107 3.223 13.645a.5.5 0 1 1-.722.691C-.846 10.838.22 6.78 7.114 2.827l.588-.329c.2-.11.406-.219.615-.328l.642-.328c.263-.131.533-.262.81-.393l-1.684.166-1.171.104-.664.054-1.357.1c-.921.062-1.877.117-2.89.164a.5.5 0 1 1-.046-1C2.962.992 3.91.938 4.825.876L6.17.776 6.83.723 7.992.619l2.521-.246.442-.036.236-.014.198-.007h.17Z'
+            />
+          </svg>
+        </a>
+      </span>
     </nav>
   )
 }


### PR DESCRIPTION
Added 'Book!' to the nav in place of tags. People do click on tags, but I don't feel like it's a great way to start with the content really. Still need a better way, but probably Explore is not a bad start. And you can access tags from explore so I think that's ok.

I made shop only appear on desktop. The shop doesn't give that much, though it's nice, and I'd rather people bought the book instead =)

![mobile nav](https://github.com/jonohey/sketchplanations/assets/1498914/0066223d-cb19-4c1d-8df1-923f595d05f9)

![desktop nav](https://github.com/jonohey/sketchplanations/assets/1498914/4dae26b3-b927-4356-bf82-6a9c584fbe83)