### PR TITLE
Adds max-image-preview-large to head

### DIFF
--- a/pages/[uid].js
+++ b/pages/[uid].js
@@ -67,6 +67,7 @@ const SketchplanationPage = ({
     <>
       <Head>
         <title>{pageTitle(title)}</title>
+        <meta name='robots' content='max-image-preview:large' />
         <meta name='description' content={truncate(prismicH.asText(body), 160)} />
         <meta key='og:title' property='og:title' content={title} />
         <meta property='og:description' content={prismicH.asText(body)} />


### PR DESCRIPTION
Adds a robots meta tag specifying large max-image-preview

Seems that Google may use image previews in results and Discover content. You can specify that it's fine to use large image previews that, on mobile, may cover the full width of the page.

I only added it, I think, to the Header of the sketch pages where there is one simple sketch.

2 references:
- https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag
- https://ignitevisibility.com/max-image-preview/

![image](https://github.com/jonohey/sketchplanations/assets/1498914/332301dc-0172-42a8-b9da-5404c982537e)
