### PR TITLE
Moved subscribe inline up top on sketch pages and gave it a garish background and some padding

### DIFF
--- a/components/SubscribeInline.module.css
+++ b/components/SubscribeInline.module.css
@@ -1,6 +1,13 @@
 .root {
-  @apply w-full px-6 pb-36 mx-auto;
+  @apply w-full pt-4 px-6 pb-4 mx-auto mb-4 mt-4 rounded-md;
   max-width: 600px;
+  background: rgb(251, 247, 218);
+  background: linear-gradient(
+    -315deg,
+    rgba(251, 247, 218, 0.25) 0%,
+    rgba(189, 180, 163, 0.05) 35%,
+    rgba(253, 96, 65, 0.25) 100%
+  );
 }
 
 .form {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -113,10 +113,10 @@ const Sketchplanations = ({ Component, pageProps }) => {
         <meta name='viewport' content='width = device-width, initial-scale = 1, minimum-scale = 1' />
       </Head>
       <Header />
+      {!['/', '/explore', '/subscribe', '/subscribed'].includes(router.pathname) && <SubscribeInline />}
       <div ref={ref} className={inter.className}>
         <Component {...pageProps} />
       </div>
-      {!['/', '/subscribe', '/subscribed'].includes(router.pathname) && <SubscribeInline />}
       {subscribeModalEnabled && (
         <SubscribeModal show={!subscribeModalDismissed && scrolled} onHide={handleSubscribeModalDismissed} />
       )}


### PR DESCRIPTION
I've been reading that my number 1 thing ought to be getting visitors onto my email list. This changes the subscribeinline to appear at the top of posts and pages like /about but not /explore

The logic being most people will visit at least one sketch so they should see the sign up. Hopefully, it won't affect SEO.

I'd _really_ like people to be directed to /subscribed after they submit the subscribeline but for the moment I added a link to /subscribed in the post submit text.

<img width="1216" alt="image" src="https://github.com/jonohey/sketchplanations/assets/1498914/02c548e4-f105-46d2-830b-e661e9a50ef9">
