### PR TITLE
Improved link and added subscribe inline to download modal

### DIFF
--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -111,13 +111,13 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 				{free || paymentIntent ? (
 					<div className="space-y-6">
 						{paymentIntent && (
-							<p className="text-lg font-semibold text-green-600">
-								Thank you for your support!
+							<p className="text-lg font-semibold">
+								Thanks for your support!
 							</p>
 						)}
 						<div>
 							<p className="mb-4">
-								Enjoy the best quality version of the sketch I have:
+								Here's a high resolution version of the sketch:
 							</p>
 							<button className="btn-primary inline-block hover:brightness-110 dark:hover:brightness-125 transition-all duration-200 transform hover:scale-105">
 								<a

--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -119,18 +119,20 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 							<p className="mb-4">
 								Enjoy the best quality version of the sketch I have:
 							</p>
-							<a
-								href={`/api/dl?uid=${sketchplanationUid}`}
-								download
-								rel="noreferrer"
-								target="_blank"
-								className="inline-block bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 border-2 border-blue-600"
-							>
-								<Download size={18} className="inline-block mr-2" />
-								Download {sketchplanationTitle}
-							</a>
+							<button className="btn-primary inline-block hover:brightness-110 dark:hover:brightness-125 transition-all duration-200 transform hover:scale-105">
+								<a
+									href={`/api/dl?uid=${sketchplanationUid}`}
+									download
+									rel="noreferrer"
+									target="_blank"
+									className="flex items-center"
+								>
+									<Download size={18} className="mr-2" />
+									Download {sketchplanationTitle}
+								</a>
+							</button>
 						</div>
-						<div className="bg-gray-100 p-4 rounded-lg border border-gray-300">
+						<div className="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg border border-gray-300 dark:border-gray-700">
 							<p>
 								Commercial usage? Please see the{" "}
 								<a
@@ -142,7 +144,6 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 									licence
 									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
 								</a>
-								.
 							</p>
 							<p>
 								Enjoying the sketches?&nbsp;
@@ -155,7 +156,7 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 									Support me on Patreon
 									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
 								</a>
-								&nbsp;or subscribe by email below.
+								&nbsp;or subscribe by email below
 							</p>
 						</div>
 						<SubscribeInline doc={subscribeInlineDoc} />

--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -117,7 +117,7 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 						)}
 						<div>
 							<p className="mb-4">
-								Here's a high resolution version of the sketch:
+								Here&apos;s a high resolution version of the sketch:
 							</p>
 							<button className="btn-primary inline-block hover:brightness-110 dark:hover:brightness-125 transition-all duration-200 transform hover:scale-105">
 								<a

--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -1,9 +1,11 @@
 import { CardElement, useElements, useStripe } from "@stripe/react-stripe-js";
+import { Download, ExternalLink } from "lucide-react";
 import Link from "next/link";
-import React, { useState } from "react";
+import { useEffect, useState } from "react";
 import CurrencyInput from "react-currency-input-field";
 
 import styles from "./PayWhatYouWant.module.css";
+import SubscribeInline from "./SubscribeInline";
 
 const CARD_OPTIONS = {
 	iconStyle: "solid",
@@ -92,27 +94,62 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 		setCardComplete(e.complete);
 	};
 
+	const [subscribeInlineDoc, setSubscribeInlineDoc] = useState(null);
+		useEffect(() => {
+		fetch("/api/subscribeInlineDoc")
+			.then((res) => res.json())
+			.then(setSubscribeInlineDoc);
+		},
+	[]);
+	
 	return (
 		<div>
-			<h2 className={styles.header}>Download highest-quality image</h2>
+			<h2 className={styles.header}>
+				Download
+			</h2>
 			<div className={styles.main}>
 				{free || paymentIntent ? (
-					<>
-						<p>
-							{paymentIntent && "Thank you. "}You can download the
-							highest-quality version I have of the sketch below:
-						</p>
-						<p>
+					<div className="space-y-6">
+						{paymentIntent && (
+							<p className="text-lg font-semibold text-green-600">
+								Thank you for your support!
+							</p>
+						)}
+						<div>
+							<p className="mb-4">
+								Enjoy the best quality version of the sketch I have:
+							</p>
 							<a
 								href={`/api/dl?uid=${sketchplanationUid}`}
 								download
 								rel="noreferrer"
 								target="_blank"
+								className="inline-block bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md transition duration-300 ease-in-out transform hover:scale-105 border-2 border-blue-600"
 							>
-								https://sketchplanations.com/api/dl?uid={sketchplanationUid}
+								<Download size={18} className="inline-block mr-2" />
+								Download {sketchplanationTitle}
 							</a>
-						</p>
-					</>
+						</div>
+						<div className="bg-gray-100 p-4 rounded-lg border border-gray-300">
+							<p>
+								Commercial usage? Please see the{" "}
+								<a href="/licence" target="_blank" className="text-blue-600 hover:underline">
+									licence
+									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
+								</a>
+								.
+							</p>
+							<p>
+								Enjoying the sketches?&nbsp;
+								<a href="https://www.patreon.com/sketchplanations" target="_blank" className="text-blue-600 hover:underline">
+									Support me on Patreon
+									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
+								</a>&nbsp;
+								or subscribe by email below.
+							</p>
+						</div>
+						<SubscribeInline doc={subscribeInlineDoc} />
+					</div>
 				) : (
 					<>
 						<p>

--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -133,7 +133,12 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 						<div className="bg-gray-100 p-4 rounded-lg border border-gray-300">
 							<p>
 								Commercial usage? Please see the{" "}
-								<a href="/licence" target="_blank" className="text-blue-600 hover:underline">
+								<a
+									href="/licence"
+									target="_blank"
+									rel="noreferrer"
+									className="text-blue-600 hover:underline"
+								>
 									licence
 									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
 								</a>
@@ -141,11 +146,16 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 							</p>
 							<p>
 								Enjoying the sketches?&nbsp;
-								<a href="https://www.patreon.com/sketchplanations" target="_blank" className="text-blue-600 hover:underline">
+								<a
+									href="https://www.patreon.com/sketchplanations"
+									target="_blank"
+									rel="noreferrer"
+									className="text-blue-600 hover:underline"
+								>
 									Support me on Patreon
 									<ExternalLink size={14} className="inline-block ml-1 mb-1" />
-								</a>&nbsp;
-								or subscribe by email below.
+								</a>
+								&nbsp;or subscribe by email below.
 							</p>
 						</div>
 						<SubscribeInline doc={subscribeInlineDoc} />

--- a/components/PayWhatYouWant.module.css
+++ b/components/PayWhatYouWant.module.css
@@ -11,7 +11,7 @@
 }
 
 .main button a {
-  @apply dark:text-white;
+  @apply text-white;
 }
 
 .form {

--- a/components/PayWhatYouWant.module.css
+++ b/components/PayWhatYouWant.module.css
@@ -10,6 +10,10 @@
   @apply text-blue;
 }
 
+.main button a {
+  @apply dark:text-white;
+}
+
 .form {
   @apply -m-2 mt-3;
 }


### PR DESCRIPTION
Layout's not perfect but I want to see if I can make the most of just after I've helped people to encourage them to subscribe to the newsletter or support me on Patreon. Plus, I thought not bad to include the licence again.

Current:
<img width="679" alt="image" src="https://github.com/user-attachments/assets/0b176747-90fb-4b75-ac99-48d158d0ef6a">

New:
<img width="752" alt="Screenshot 2024-09-18 at 17 47 56" src="https://github.com/user-attachments/assets/c685d07a-0111-4891-b681-45b675373748">
<img width="407" alt="Screenshot 2024-09-18 at 17 50 38" src="https://github.com/user-attachments/assets/81fb2591-418f-4d63-bddb-ee487da16100">

Dark:
![image](https://github.com/user-attachments/assets/89cb5544-9f9b-4af0-9d0f-4e99485a54ff)

