### PR TITLE
Added a track event for when people actually downloaded a sketch

### DIFF
--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -126,6 +126,9 @@ const PayWhatYouWant = ({ sketchplanationUid, sketchplanationTitle }) => {
 									rel="noreferrer"
 									target="_blank"
 									className="flex items-center"
+									onClick={() => {
+										track('Downloaded-sketch', { sketch: `${sketchplanationTitle}` });
+									}}
 								>
 									<Download size={18} className="mr-2" />
 									Download {sketchplanationTitle}

--- a/components/PayWhatYouWant.js
+++ b/components/PayWhatYouWant.js
@@ -1,4 +1,5 @@
 import { CardElement, useElements, useStripe } from "@stripe/react-stripe-js";
+import { track } from "@vercel/analytics";
 import { Download, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";


### PR DESCRIPTION

Event name:
Downloaded-sketch
Property:
sketch: <sketch title>


![image](https://github.com/user-attachments/assets/9b55b119-07c7-449b-8adc-124dde99789d)
