### PR TITLE
Added a Subscribe track event to subscribeInline including a source and pageUrl

### DIFF
--- a/components/SubscribeInline.js
+++ b/components/SubscribeInline.js
@@ -1,3 +1,4 @@
+import { track } from "@vercel/analytics";
 import { sendGTMEvent } from "gtm";
 import { useState } from "react";
 
@@ -33,6 +34,12 @@ const SubscribeInline = ({ doc }) => {
 				data: "inline",
 			});
 		} catch (e) {} // eslint-disable-line no-empty
+
+		try {
+			track('Subscribe', { source: 'inline-subscribe', pageUrl: window.location.pathname });
+		} catch (error) {
+			console.error('Failed to send Vercel analytics event:', error);
+		}
 
 		setSubmitted(true);
 		setProcessing(false);


### PR DESCRIPTION
Event:
Subscribe

Source:
inline-subscribe

pageUrl:
/<path>

Fires on inline subscribed eg on the side of sketch pages, in the footer and after download

Doesn't yet do the /subscribe page which is from a different file.