### PR TITLE
Stopped displaying the final page number and added links to Search, Categories and Archive underneath the pagination

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -1,9 +1,8 @@
-import styles from "./Pagination.module.css";
+import classNames from "classnames";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Fragment } from "react";
 import FancyLink from "./FancyLink";
-import { ChevronRight } from "lucide-react";
-import { ChevronLeft } from "lucide-react";
-import classNames from "classnames";
+import styles from "./Pagination.module.css";
 
 const commonIconProps = {
 	color: "var(--color-blue)",
@@ -65,6 +64,20 @@ const Pagination = ({ currentPage, totalPages, className }) => {
 					</FancyLink>
 				)}
 			</nav>
+
+			<div className="text-center mt-8">
+				<FancyLink href="/search" className={styles.footerLink}>
+					Search
+				</FancyLink>
+				<span className="mx-2">·</span>
+				<FancyLink href="/categories" className={styles.footerLink}>
+					Categories
+				</FancyLink>
+				<span className="mx-2">·</span>
+				<FancyLink href="/archive" className={styles.footerLink}>
+					Archive
+				</FancyLink>
+			</div>
 		</div>
 	);
 };
@@ -94,8 +107,6 @@ function getPageNumbers(currentPage, totalPages) {
 		if (currentPage < totalPages - 3) {
 			pageNumbers.push("…");
 		}
-
-		pageNumbers.push(totalPages);
 	}
 
 	return pageNumbers;


### PR DESCRIPTION
Because the final page number gives the worst sketches.

And if you're clicking lots of pages in the pagination you're probably better off with Search, Categories or Archive

<img width="389" alt="image" src="https://github.com/user-attachments/assets/386bb233-d5d6-4710-90dc-18d13b2dfb7c">
