### PR TITLE
Removed span messing up text headers and responsive layout

### DIFF
--- a/components/TextHeader.js
+++ b/components/TextHeader.js
@@ -51,9 +51,7 @@ const TextHeader = ({ as = "h1", children, ...props }) => {
 					padding={2}
 					type="underline"
 				>
-					<span style={{ whiteSpace: 'nowrap', position: 'relative', zIndex: 1 }}>
-						{children}
-					</span>
+					{children}
 				</RoughNotation>
 			)}
 		</div>


### PR DESCRIPTION
I'd messed up the layout by messing with the TitleHeader styles
![image](https://github.com/user-attachments/assets/914d8109-1a35-4901-b7be-9c1b707a99e2)
