### PR TITLE
Changed /explore /tags and a couple of others to permanent redirects …

### DIFF
--- a/redirects.mjs
+++ b/redirects.mjs
@@ -2,12 +2,12 @@ export default [
 	{
 		source: "/explore",
 		destination: "/search",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/podcast",
 		destination: "https://podcast.sketchplanations.com/",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/book",
@@ -52,22 +52,22 @@ export default [
 	{
 		source: "/tags",
 		destination: "/categories",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/tags/:tag",
 		destination: "/categories/:tag",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/sketchplanations",
 		destination: "/",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/sketchplanator",
 		destination: "/",
-		permanent: false,
+		permanent: true,
 	},
 	{
 		source: "/microadventures",


### PR DESCRIPTION
…to tidy up search results

Google and Bing sometimes still picked up /explore and /tags as results instead of the newer /search and /categories. I wanted this to go away so set those redirects to permanent: true