### PR TITLE
Seo noindex for search params and ref referrers

### DIFF
--- a/pages/[uid].js
+++ b/pages/[uid].js
@@ -76,6 +76,12 @@ const SketchplanationPage = ({
 	olderUid,
 	newerUid,
 }) => {
+	const router = useRouter();
+	// This checks for ref= query param in the url and sets the noindex meta tag if it's present
+	// On recommendation from SEO expert.
+	const shouldNoIndex = router.query.ref !== undefined;
+	const robotsContent = `max-image-preview:large${shouldNoIndex ? ', noindex, nofollow' : ''}`;
+
 	const {
 		data: {
 			image,
@@ -102,8 +108,6 @@ const SketchplanationPage = ({
 		redbubbleLinkUrl,
 		onViewLicence: () => setLicenceModalOpen(true),
 	};
-
-	const router = useRouter();
 
 	useHotkeys(
 		"right, k",
@@ -148,7 +152,7 @@ const SketchplanationPage = ({
 		<Fragment key={uid}>
 			<Head>
 				<title>{pageTitle(title)}</title>
-				<meta name="robots" content="max-image-preview:large" />
+				<meta name="robots" content={robotsContent} />
 				<meta
 					name="description"
 					content={truncate(prismicH.asText(body), 160)}

--- a/pages/search.js
+++ b/pages/search.js
@@ -10,6 +10,7 @@ const Search = () => {
 	const { query, setQuery, clear, busy } = useSearch();
 
 	const dynamicPageTitle = isPresent(query) ? `Search: ${query}` : "Search";
+	const queryIsPresent = isPresent(query);
 
 	return (
 		<>
@@ -19,6 +20,9 @@ const Search = () => {
 					name="description"
 					content="Search and explore hundreds of simple, clear explanations on science, creativity, psychology, and more. Find your favourite Sketchplanations in seconds."
 				/>
+				{queryIsPresent && (
+					<meta name="robots" content="noindex, nofollow" />
+				)}
 			</Head>
 			<header className="pt-6 px-4">
 				<div className="prose mx-auto text-center">


### PR DESCRIPTION
To address these recommendations:

You need to block search pages from indexing (for example: /?q=transformation).
This can be done in Robots.txt by adding the line Disallow: /?q= but it would be better to do this by adding the meta tag <meta name="robots" content="noindex, nofollow" /> to the code of such pages - it will be more reliable.
The same should be done with referral URLs, such as: /?ref=labnotes.org.

Closes #423 