### PR TITLE
Added canonical urls to pretty much all pages to fix Duplicate without user-selected canonical errors in search console

### DIFF
--- a/pages/[uid].js
+++ b/pages/[uid].js
@@ -152,6 +152,7 @@ const SketchplanationPage = ({
 		<Fragment key={uid}>
 			<Head>
 				<title>{pageTitle(title)}</title>
+				<link rel="canonical" href={`https://www.sketchplanations.com/${uid}`} />
 				<meta name="robots" content={robotsContent} />
 				<meta
 					name="description"

--- a/pages/about.js
+++ b/pages/about.js
@@ -12,6 +12,7 @@ const About = ({ document }) => {
 					name="description"
 					content="Learn about the inspiration behind Sketchplanations, the process of creating weekly sketches, and how you can support the project."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/about" />
 			</Head>
 			<Page document={document} />
 		</>

--- a/pages/archive.js
+++ b/pages/archive.js
@@ -35,6 +35,7 @@ const Archive = ({ initialSketchplanations }) => {
 					name="description"
 					content="Browse the full visual archive of over a decade of Sketchplanations. Discover simple, clear sketches that explain complex ideas, and explore topics that inspire your curiosity."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/archive" />
 			</Head>
 			<div className="pt-6 px-6 text-center">
 				<TextHeader>Archive</TextHeader>

--- a/pages/big-ideas-little-pictures.js
+++ b/pages/big-ideas-little-pictures.js
@@ -12,6 +12,7 @@ const Book = ({ document }) => {
 					name="description"
 					content="Discover 'Big Ideas, Little Pictures' by Jono Hey—a delightful book that simplifies complex ideas with clear illustrations. Explore reviews, FAQs, see what's inside, and find out how to order your copy."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/big-ideas-little-pictures" />
 			</Head>
 			<Page document={document} />
 		</>

--- a/pages/categories.js
+++ b/pages/categories.js
@@ -32,6 +32,7 @@ const Categories = ({ tagsByName, tagsByCount }) => {
 					name="description"
 					content="Explore Sketchplanations by topic to discover clear, simple explanations on subjects like science, creativity, psychology, and more. Find sketches and illustrations that explain the topics you care about most."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/categories" />
 			</Head>
 			<div className="pt-6 px-6 text-center">
 				<TextHeader>Categories</TextHeader>

--- a/pages/categories/[tag].js
+++ b/pages/categories/[tag].js
@@ -25,6 +25,7 @@ const Tag = ({ tag, sketchplanations }) => {
 					name="description"
 					content={`Discover sketches, drawings, illustrations, and pictures that explain key ideas related to ${tag}. Explore visual explanations that make understanding the topic of ${tag} simple.`}
 				/>
+				<link rel="canonical" href={`https://www.sketchplanations.com/categories/${router.query.tag}`} />
 				<script
 					type="application/ld+json"
 					dangerouslySetInnerHTML={{

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,6 +18,7 @@ const Home = ({ sketchplanations, subscribeInlineDoc }) => {
 					name="description"
 					content="Sketchplanations explains the world one sketch at a time. Discover clear, simple sketches that break down ideas from science, creativity, psychology, and more. Explore recent sketches, search for topics, and share your favourites. Start here."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com" />
 			</Head>
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
 				<div className="prose sm:prose-lg lg:prose-xl mx-auto text-center">

--- a/pages/licence.js
+++ b/pages/licence.js
@@ -8,11 +8,12 @@ const Licence = ({ document }) => {
 		<>
 			<Head>
 				<title>{pageTitle("Licence")}</title>
+				<meta
+					name="description"
+					content="How to share and use Sketchplanations considerately. Follow the license terms to help more people find and enjoy the sketches they love."
+				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/licence" />
 			</Head>
-			<meta
-				name="description"
-				content="How to share and use Sketchplanations considerately. Follow the license terms to help more people find and enjoy the sketches they love."
-			/>
 			<Page document={document} />
 		</>
 	);

--- a/pages/list.js
+++ b/pages/list.js
@@ -68,6 +68,7 @@ const SketchList = ({ initialSketches }) => {
 					name="description"
 					content="Browse the full list of all Sketchplanations, organized A-Z or by date. Explore titles that span over a decade of sketches, offering clear and simple explanations on a wide range of topics."
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/list" />
 			</Head>
 			<div className="max-w-7xl mx-auto px-5 py-6">
 				<div className="pt-6 px-6 text-center">

--- a/pages/search.js
+++ b/pages/search.js
@@ -23,6 +23,7 @@ const Search = () => {
 				{queryIsPresent && (
 					<meta name="robots" content="noindex, nofollow" />
 				)}
+				<link rel="canonical" href="https://www.sketchplanations.com/search" />
 			</Head>
 			<header className="pt-6 px-4">
 				<div className="prose mx-auto text-center">

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -47,6 +47,7 @@ const Subscribe = ({ subscribeDocument, subscribedDocument }) => {
 					name="description"
 					content="Get a new Sketchplanation in your inbox every week"
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/subscribe" />
 			</Head>
 			<Page document={subscribeDocument}>
 				<form onSubmit={handleSubmit}>

--- a/pages/subscribed.js
+++ b/pages/subscribed.js
@@ -8,6 +8,7 @@ const Subscribed = ({ document }) => {
 		<>
 			<Head>
 				<title>{pageTitle("Subscribed")}</title>
+				<link rel="canonical" href="https://www.sketchplanations.com/subscribed" />
 			</Head>
 			<Page document={document} />
 		</>

--- a/pages/thanks.js
+++ b/pages/thanks.js
@@ -12,6 +12,7 @@ const Thanks = ({ document }) => {
 					name="description"
 					content="Sketchplanations exists thanks to the generous patrons and followers who support me making them"
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/thanks" />
 			</Head>
 			<Page document={document} />
 		</>

--- a/pages/wisdom.js
+++ b/pages/wisdom.js
@@ -12,6 +12,7 @@ const Wisdom = ({ document }) => {
 					name="description"
 					content="A collection of wise words and quotes to live by"
 				/>
+				<link rel="canonical" href="https://www.sketchplanations.com/wisdom" />
 			</Head>
 			<Page document={document} />
 		</>


### PR DESCRIPTION
See #427 

Hopefully should make the 849 or so links on here go away:
https://search.google.com/search-console/index/drilldown?resource_id=sc-domain%3Asketchplanations.com&item_key=CAMYDyAC