### PR TITLE
Added Copy link functionality to Ctas and amended link icons and spacing

### DIFF
--- a/components/SketchplanationCtas.js
+++ b/components/SketchplanationCtas.js
@@ -1,6 +1,7 @@
 import { track } from '@vercel/analytics';
 import classNames from "classnames";
-import { ExternalLink } from "lucide-react";
+import { Check, Copy, CreativeCommons, Download, Headphones, Link2, ShoppingCart } from "lucide-react";
+import { useState } from "react";
 import { RoughNotation } from "react-rough-notation";
 import styles from "./SketchplanationCtas.module.css";
 
@@ -12,13 +13,11 @@ const SketchplanationCtas = ({
 	onViewLicence,
 	variant = "normal",
 }) => {
+	const [copied, setCopied] = useState(false);
+
 	return (
 		<ul
-			className={classNames(
-				styles.ctas,
-				variant === "normal" && styles.ctasNormal,
-				variant === "lightbox" && styles.ctasLightbox,
-			)}
+			className={variant === "lightbox" ? styles.ctasLightbox : styles.ctas}
 		>
 			{podcastLinkUrl && (
 				<li>
@@ -32,6 +31,7 @@ const SketchplanationCtas = ({
 								styles.cta,
 								variant === "normal" && styles.ctaNormal,
 								variant === "lightbox" && styles.ctaLightbox,
+								variant === "lightbox" ? styles.ctaHoverLightbox : styles.ctaHover
 							)}
 							href={podcastLinkUrl}
 							target="_blank"
@@ -41,8 +41,10 @@ const SketchplanationCtas = ({
 								track('Sketch-link-podcast-episode', { sketch: `${title}` });
 							}}
 						>
-							Listen
-							<ExternalLink size={16} />
+							<span className="flex items-center gap-x-1">
+								Listen
+								<Headphones size={16} />
+							</span>
 						</a>
 					</RoughNotation>
 				</li>
@@ -53,6 +55,7 @@ const SketchplanationCtas = ({
 						styles.cta,
 						variant === "normal" && styles.ctaNormal,
 						variant === "lightbox" && styles.ctaLightbox,
+						variant === "lightbox" ? styles.ctaHoverLightbox : styles.ctaHover
 					)}
 					type="button"
 					onClick={() => {
@@ -60,7 +63,10 @@ const SketchplanationCtas = ({
 						onDownload();
 					}}
 				>
-					Download
+					<span className="flex items-center gap-x-1">
+						Download
+						<Download size={16} />
+					</span>
 				</button>
 			</li>
 			{redbubbleLinkUrl && (
@@ -70,6 +76,7 @@ const SketchplanationCtas = ({
 							styles.cta,
 							variant === "normal" && styles.ctaNormal,
 							variant === "lightbox" && styles.ctaLightbox,
+							variant === "lightbox" ? styles.ctaHoverLightbox : styles.ctaHover
 						)}
 						href={redbubbleLinkUrl}
 						target="_blank"
@@ -78,8 +85,10 @@ const SketchplanationCtas = ({
 							track('Sketch-link-prints', { sketch: `${title}` });
 						}}
 					>
-						Prints
-						<ExternalLink size={16} />
+						<span className="flex items-center gap-x-1">
+							Prints
+							<ShoppingCart size={16} />
+						</span>
 					</a>
 				</li>
 			)}		
@@ -89,6 +98,7 @@ const SketchplanationCtas = ({
 						styles.cta,
 						variant === "normal" && styles.ctaNormal,
 						variant === "lightbox" && styles.ctaLightbox,
+						variant === "lightbox" ? styles.ctaHoverLightbox : styles.ctaHover
 					)}
 					type="button"
 					onClick={() => {
@@ -96,7 +106,67 @@ const SketchplanationCtas = ({
 						onViewLicence();
 					}}
 				>
-					Licence
+					<span className="flex items-center gap-x-1">
+						Licence
+						<CreativeCommons size={16} />
+					</span>
+				</button>
+			</li>
+			<li className="relative">
+				<div 
+					className={classNames(
+						"absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 rounded bg-gray-900 text-white text-sm transition-all duration-200",
+						copied ? "opacity-100 translate-y-0 visible" : "opacity-0 translate-y-1 invisible pointer-events-none"
+					)}
+				>
+					Copied!
+				</div>
+				<button
+					className={classNames(
+						styles.cta,
+						variant === "normal" && styles.ctaNormal,
+						variant === "lightbox" && styles.ctaLightbox,
+						variant === "lightbox" ? styles.copyButtonLightbox : styles.copyButton,
+						styles.copyButtonHover,
+						"group"
+					)}
+					type="button"
+					onClick={() => {
+						const url = window.location.href;
+						navigator.clipboard.writeText(url).then(() => {
+							setCopied(true);
+							track('Sketch-link-copy', { sketch: `${title}` });
+							
+							setTimeout(() => {
+								setCopied(false);
+							}, 2000);
+						});
+					}}
+				>
+					<span className="flex items-center gap-x-1">
+						Copy link
+						{copied ? (
+							<Check size={16} className="text-green-500 transition-all duration-200" />
+						) : (
+							<span className="relative w-4 h-4">
+								<Link2 
+									size={16} 
+									className={classNames(
+										"absolute top-0 left-0",
+										"group-hover:invisible"
+									)} 
+								/>
+								<Copy 
+									size={16} 
+									className={classNames(
+										"absolute top-0 left-0",
+										"opacity-0 -translate-y-2 invisible",
+										"group-hover:opacity-100 group-hover:translate-y-0 group-hover:visible group-hover:transition-all group-hover:duration-75"
+									)} 
+								/> 
+							</span>
+						)}
+					</span>
 				</button>
 			</li>
 		</ul>

--- a/components/SketchplanationCtas.module.css
+++ b/components/SketchplanationCtas.module.css
@@ -1,14 +1,39 @@
 .ctas {
-  @apply flex justify-center gap-x-4 text-sm;
+  @apply flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm pt-2;
 }
 
-.cta {
-  @apply text-blue dark:text-blueLight underline font-semibold flex items-center gap-x-1;
+@screen sm {
+  .ctas {
+    @apply gap-x-6 gap-y-3;
+  }
 }
 
 .ctasLightbox {
+  composes: ctas;
+  @apply pt-0;
+}
+
+.cta {
+  @apply text-blue dark:text-blueLight font-semibold flex items-center gap-x-1;
 }
 
 .ctaLightbox {
   @apply text-white dark:text-white;
+}
+
+.ctaHover {
+  @apply rounded px-2 py-1 -mx-2 -my-1 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800;
+}
+
+.ctaHoverLightbox {
+  composes: ctaHover;
+  @apply hover:text-text dark:hover:text-text;
+}
+
+.copyButton {
+  composes: ctaHover;
+}
+
+.copyButtonLightbox {
+  composes: ctaHoverLightbox;
 }

--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -235,7 +235,7 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					<AnimatePresence>
 						{isOpen && !isLoading && (
 							<motion.div
-								className="fixed z-20 bottom-0 left-0 right-0 flex items-center justify-center h-12 border-t border-[rgba(255,255,255,0.05)] backdrop-blur-sm"
+								className="fixed z-20 bottom-0 left-0 right-0 flex items-center justify-center h-14 border-t border-[rgba(255,255,255,0.05)] backdrop-blur-sm"
 								initial={{
 									translateY: 100,
 								}}

--- a/pages/[uid].module.css
+++ b/pages/[uid].module.css
@@ -220,9 +220,12 @@
 
 .ctas-area {
   grid-area: ctas;
-  /* @apply py-3 mx-5 sm:mx-0 mb-5 border-t border-b border-border; */
-  @apply px-5 sm:px-0 mb-7 mx-auto lg:mx-0;
-  max-width: var(--maxWidth);
+  @apply px-0 sm:px-5 mb-7 mx-auto lg:mx-0;
+  max-width: none;
+
+  @screen sm {
+    max-width: var(--maxWidth);
+  }
 }
 
 .image {


### PR DESCRIPTION
Included Vercel tracking for the copy link functionality:
`track('Sketch-link-copy', { sketch: `${title}` });`

![image](https://github.com/user-attachments/assets/f436f82c-1ed8-4952-a684-86bd775af8e5)

![image](https://github.com/user-attachments/assets/cbad3c09-f38b-45ff-b9b3-4dc01cb5f0bf)

![image](https://github.com/user-attachments/assets/3f28efa5-39a4-45a2-b5de-134852cc5439)
