### PR TITLE
changed gitignore to be /rss.xml not/rss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ yarn-error.log*
 .vercel
 data/*
 !data/.gitkeep
-/public/rss
+/public/rss.xml
 
 # Local Netlify folder
 .netlify


### PR DESCRIPTION
Because otherwise the full rss.xml as buillt locally was being committed to the repo but it's built fresh each deployment.

Previously was /public/rss now is /public/rss.xml