### PR TITLE
updated path-to-regexp to 8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"nextjs-progressbar": "^0.0.16",
 		"node-fetch": "^3.3.2",
 		"node-html-parser": "^6.1.13",
-		"path-to-regexp": "^8.0.0",
+		"path-to-regexp": "^8.2.0",
 		"polished": "^4.3.1",
 		"postcss-flexbugs-fixes": "^5.0.2",
 		"postgres": "^3.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^6.1.13
         version: 6.1.13
       path-to-regexp:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^8.2.0
+        version: 8.2.0
       polished:
         specifier: ^4.3.1
         version: 4.3.1
@@ -3543,8 +3543,8 @@ packages:
   path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
 
-  path-to-regexp@8.0.0:
-    resolution: {integrity: sha512-GAWaqWlTjYK/7SVpIUA6CTxmcg65SP30sbjdCvyYReosRkk7Z/LyHWwkK3Vu0FcIi0FNTADUs4eh1AsU5s10cg==}
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
 
   path-type@4.0.0:
@@ -8666,7 +8666,7 @@ snapshots:
 
   path-to-regexp@6.2.1: {}
 
-  path-to-regexp@8.0.0: {}
+  path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
As I couldn't make it work through dependabot. Used for redirects