### PR TITLE
Fixed search shortcut due to react-hotkeys breaking change

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -31,7 +31,7 @@ const Header = () => {
 	useHotkeys("/", (e) => {
 		e.preventDefault();
 		enterSearch();
-	});
+	}, { useKey: true });
 
 	useEffect(() => {
 		const handleRouteChange = () => setIsOpen(false);


### PR DESCRIPTION
According to the v5.0.0 release notes, there was a breaking change:
> The hook now only listens to the code of the hotkey, not the produced key. This will get rid of all the confusion between different keyboard layouts, multiple accidental triggers and so on.
The key change is that in version 5, the hook now listens to the key code instead of the produced key by default. For special characters like /, you need to set useKey: true to listen to the produced key.