### PR TITLE
529 fix jpg images display

### DIFF
--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -1,7 +1,7 @@
+import { PrismicNextImage } from "@prismicio/next";
 import { AnimatePresence, motion } from "framer-motion";
 import { debounce } from "lodash";
 import { LoaderCircle } from "lucide-react";
-import Image from "next/image";
 import {
 	useCallback,
 	useContext,
@@ -14,12 +14,12 @@ import { Dialog, Modal, ModalOverlay } from "react-aria-components";
 
 const MotionModal = motion.create(Modal);
 // const MotionDialog = motion.create(Dialog);
-const MotionImage = motion.create(Image);
+const MotionImage = motion.create(PrismicNextImage);
 
 import Context from "context";
 
 const SketchplanationImage = ({ image, title, priority = false, children }) => {
-	const { width, height } = image.dimensions;
+	const { width, height, url } = image.dimensions ? image : { width: undefined, height: undefined, url: image?.url };
 
 	const { setDecorationHidden } = useContext(Context);
 
@@ -79,13 +79,18 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 
 	const dialog = useRef(null);
 
+	// Determine imgixParams based on file extension
+	const isJpg = image.url.match(/\.jpe?g($|[?&])/i);
+	const imgixParams = isJpg ? { auto: "format" } : undefined;
+	const quality = isJpg ? 95 : undefined;
+
 	return (
 		<>
 			<div className="relative">
-				<Image
+				<PrismicNextImage
+					field={image}
 					className="bg-paper cursor-zoom-in mx-auto"
 					ref={imageRef}
-					src={image.url}
 					width={width}
 					height={height}
 					alt={image.alt || `${title} - Sketchplanations`}
@@ -96,9 +101,10 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					tabIndex="0"
 					style={{
 						opacity,
-						// boxShadow: "0 2.3rem 1rem -2rem var(--color-sketchShadow)",
 						boxShadow: "0 2.3rem 1rem -2rem hsla(0, 0%, 0%, 0.1)",
 					}}
+					imgixParams={imgixParams}
+					quality={quality}
 				/>
 				<motion.div
 					className="absolute inset-0 flex items-center justify-center text-bg pointer-events-none backdrop-blur-lg"
@@ -164,17 +170,17 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					animate={
 						isOpen && !isLoading
 							? {
-									top: "1.5rem",
-									left: "0",
-									width: "100vw",
-									height: "calc(var(--visual-viewport-height) - 6rem)",
-								}
+								top: "1.5rem",
+								left: "0",
+								width: "100vw",
+								height: "calc(var(--visual-viewport-height) - 6rem)",
+							}
 							: {
-									top: initialImageRect.top,
-									left: initialImageRect.left,
-									width: initialImageRect.width,
-									height: initialImageRect.height,
-								}
+								top: initialImageRect.top,
+								left: initialImageRect.left,
+								width: initialImageRect.width,
+								height: initialImageRect.height,
+							}
 					}
 					transition={{
 						type: "spring",
@@ -186,50 +192,18 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					<Dialog
 						ref={dialog}
 						className="w-full h-full"
-						// drag="y"
-						// dragMomentum={false}
-						// onDragEnd={(e, { offset, velocity }) => {
-						// 	if (
-						// 		offset.y > window.innerHeight * 0.75 ||
-						// 		velocity.y > 10 ||
-						// 		offset.y < -window.innerHeight * 0.75 ||
-						// 		velocity.y < -10
-						// 	) {
-						// 		// Animate back to original position
-						// 		animate(
-						// 			dialog.current,
-						// 			{ y: 0 },
-						// 			{
-						// 				type: "spring",
-						// 				damping: 10,
-						// 				stiffness: 200,
-						// 				mass: 0.1,
-						// 			},
-						// 		);
-						// 		close();
-						// 	} else {
-						// 		animate(
-						// 			dialog.current,
-						// 			{ y: 0 },
-						// 			{
-						// 				type: "spring",
-						// 				damping: 10,
-						// 				stiffness: 200,
-						// 				mass: 0.1,
-						// 			},
-						// 		);
-						// 	}
-						// }}
 					>
-						<MotionImage
+						<PrismicNextImage
+							field={image}
 							className="object-contain cursor-zoom-out"
-							src={image.url}
 							alt={image.alt || `${title} - Sketchplanations`}
 							sizes="calc(100w - 3rem)"
 							fill={true}
 							onClick={close}
 							priority
 							onLoad={() => setIsLoading(false)}
+							imgixParams={imgixParams}
+							quality={quality}
 						/>
 					</Dialog>
 					<AnimatePresence>

--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -93,7 +93,6 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					ref={imageRef}
 					width={width}
 					height={height}
-					alt={image.alt || `${title} - Sketchplanations`}
 					sizes="(min-width: 66rem) 645px, (min-width: 64rem) 62w, (min-width: 40rem) calc(100w - 3rem), 100w"
 					priority={priority}
 					onClick={open}
@@ -196,7 +195,6 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 						<PrismicNextImage
 							field={image}
 							className="object-contain cursor-zoom-out"
-							alt={image.alt || `${title} - Sketchplanations`}
 							sizes="calc(100w - 3rem)"
 							fill={true}
 							onClick={close}

--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -17,7 +17,7 @@ const MotionModal = motion.create(Modal);
 
 import Context from "context";
 
-const SketchplanationImage = ({ image, priority = false, children }) => {
+const SketchplanationImage = ({ image, title, priority = false, children }) => {
 	const { width, height } = image.dimensions ? image : { width: undefined, height: undefined };
 
 	const { setDecorationHidden } = useContext(Context);
@@ -83,11 +83,17 @@ const SketchplanationImage = ({ image, priority = false, children }) => {
 	const imgixParams = isJpg ? { auto: "format" } : undefined;
 	const quality = isJpg ? 95 : undefined;
 
+	const fallbackAlt = `${title} - Sketchplanations`;
+	const imageWithAlt = {
+		...image,
+		alt: image.alt || fallbackAlt,
+	};
+
 	return (
 		<>
 			<div className="relative">
 				<PrismicNextImage
-					field={image}
+					field={imageWithAlt}
 					className="bg-paper cursor-zoom-in mx-auto"
 					ref={imageRef}
 					width={width}
@@ -192,7 +198,7 @@ const SketchplanationImage = ({ image, priority = false, children }) => {
 						className="w-full h-full"
 					>
 						<PrismicNextImage
-							field={image}
+							field={imageWithAlt}
 							className="object-contain cursor-zoom-out"
 							sizes="calc(100w - 3rem)"
 							fill={true}

--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -14,12 +14,11 @@ import { Dialog, Modal, ModalOverlay } from "react-aria-components";
 
 const MotionModal = motion.create(Modal);
 // const MotionDialog = motion.create(Dialog);
-const MotionImage = motion.create(PrismicNextImage);
 
 import Context from "context";
 
-const SketchplanationImage = ({ image, title, priority = false, children }) => {
-	const { width, height, url } = image.dimensions ? image : { width: undefined, height: undefined, url: image?.url };
+const SketchplanationImage = ({ image, priority = false, children }) => {
+	const { width, height } = image.dimensions ? image : { width: undefined, height: undefined };
 
 	const { setDecorationHidden } = useContext(Context);
 


### PR DESCRIPTION
jpg images were not displaying well on Sketchplanations page (and in smaller places like the gallery and search, but I left those as they're small) because jpgs were being auto compressed and it was making them greenish and introducing artifacts. Older sketches used jpgs which is not great, but I still wanted to fix them eg https://sketchplanations.com/release-strategy

I changed the main Sketchplanation images to use PrismicNextImage where I could control the props going to the image processing. Here's after :: before
![image](https://github.com/user-attachments/assets/71117119-ee4b-455c-8a76-4613580702ad)
