### PR TITLE
Enabling Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@trivago/prettier-plugin-sort-imports": "^5.2.2",
 		"@vercel/analytics": "^1.5.0",
 		"@vercel/kv": "^3.0.0",
+		"@vercel/speed-insights": "^1.2.0",
 		"classnames": "^2.5.1",
 		"easing-coordinates": "^2.0.2",
 		"fast-sort": "^3.4.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import { PrismicPreview } from "@prismicio/next";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import BuyMeACoffee from "components/BuyMeACoffee";
 import Footer from "components/Footer";
 import Header from "components/Header";
@@ -108,6 +109,7 @@ const Sketchplanations = ({ Component, pageProps }) => {
 					<Footer />
 				</div>
 				<Analytics />
+				<SpeedInsights />
 			</Context.Provider>
 		</PrismicPreview>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@vercel/kv':
         specifier: ^3.0.0
         version: 3.0.0
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1963,6 +1966,29 @@ packages:
 
   '@vercel/ruby@2.2.1':
     resolution: {integrity: sha512-DsmTCggOa/Uvt/9JkafXx9U+Bz5eNIb6Bs422EOQo2zKwcxW88ITSh8mM5m0dQ0+B4k02X/moVim6iFa4sjazg==}
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/static-build@2.7.16':
     resolution: {integrity: sha512-vRIY1tLTuGSkQaMdCaV1cb5wBCC+HU081TtwjlGQQETdjZcqgkl+kJEOFfICzk5iSVluRRMTkUslc0wHM7vqXQ==}
@@ -7162,6 +7188,11 @@ snapshots:
 
   '@vercel/ruby@2.2.1': {}
 
+  '@vercel/speed-insights@1.2.0(next@15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    optionalDependencies:
+      next: 15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+
   '@vercel/static-build@2.7.16':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
@@ -8025,7 +8056,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8047,7 +8078,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates Vercel Speed Insights by adding the package and rendering `SpeedInsights` in the app entry.
> 
> - **App Initialization**:
>   - Render `SpeedInsights` in `pages/_app.js` and import from `@vercel/speed-insights/next`.
> - **Dependencies**:
>   - Add `@vercel/speed-insights` to `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85ca89ce61515993a4d5545ea0a1d6fa80751806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->