### PR TITLE
Adjusted Vercel event tracking to account for it being a new-tab extension

### DIFF
--- a/tests/api/extension/new-tab-handler.test.js
+++ b/tests/api/extension/new-tab-handler.test.js
@@ -38,17 +38,22 @@ const createResponse = () => {
 	};
 };
 
-const createRequest = (method, overrides = {}) => ({
-	method,
-	headers: {
-		host: "test.local",
-		cookie: "",
-		"user-agent": "vitest",
-		"x-forwarded-for": "127.0.0.1",
-		...overrides.headers,
-	},
-	...overrides,
-});
+const createRequest = (method, overrides = {}) => {
+	const url = overrides.url ?? "/api/extension/new-tab";
+	return {
+		method,
+		url,
+		socket: { remoteAddress: "203.0.113.99" },
+		headers: {
+			host: "test.local",
+			cookie: "",
+			"user-agent": "vitest",
+			"x-forwarded-for": "127.0.0.1",
+			...overrides.headers,
+		},
+		...overrides,
+	};
+};
 
 describe("createNewTabHandler", () => {
 	let originalMathRandom;
@@ -115,7 +120,14 @@ describe("createNewTabHandler", () => {
 				status: "success",
 				sketchTitle: "Daily habits",
 			},
-			{ headers: req.headers },
+			{
+				headers: expect.objectContaining({
+					...req.headers,
+					referer: "https://test.local/api/extension/new-tab",
+					"user-agent": "vitest",
+					"x-forwarded-for": "127.0.0.1",
+				}),
+			},
 		);
 	});
 
@@ -147,7 +159,12 @@ describe("createNewTabHandler", () => {
 				status: "invalid_method",
 				method: "POST",
 			},
-			{ headers: req.headers },
+			{
+				headers: expect.objectContaining({
+					...req.headers,
+					referer: "https://test.local/api/extension/new-tab",
+				}),
+			},
 		);
 	});
 
@@ -169,7 +186,12 @@ describe("createNewTabHandler", () => {
 				apiVersion: "v1",
 				status: "not_found",
 			},
-			{ headers: req.headers },
+			{
+				headers: expect.objectContaining({
+					...req.headers,
+					referer: "https://test.local/api/extension/new-tab",
+				}),
+			},
 		);
 	});
 
@@ -193,7 +215,12 @@ describe("createNewTabHandler", () => {
 				status: "error",
 				errorType: "Error",
 			},
-			{ headers: req.headers },
+			{
+				headers: expect.objectContaining({
+					...req.headers,
+					referer: "https://test.local/api/extension/new-tab",
+				}),
+			},
 		);
 	});
 


### PR DESCRIPTION
Summary
The Vercel server-side analytics log showed Can't find VERCEL_URL, which happens when the request lacks a referer (or VERCEL_URL env). For extension calls there’s usually no referer header, so the analytics endpoint didn’t know which domain to attribute the event to and skipped it.
Updated createNewTabHandler to build a complete header set before calling track: normalize multi-valued headers, fill in a referer derived from req.headers.host and req.url, supply a fallback user-agent, and fall back to the socket IP when x-forwarded-for is missing. This satisfies the server-side analytics requirements.
Adjusted the Vitest suite to assert the enriched headers and added defaults (req.url, socket address) so tests cover the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Builds complete tracking headers (referer, user-agent, IP) for extension new-tab analytics and updates tests to assert enriched headers.
> 
> - **API (extension new-tab)**:
>   - Add `normalizeHeaders` and `buildTrackingHeaders` to construct full analytics headers.
>   - Update `createTracker(apiVersion, req)` to derive headers from `req` (referer from `host` + `url`, default `user-agent`, fallback `x-forwarded-for`).
>   - Use built headers when calling `track` and pass `req` instead of raw headers.
> - **Tests**:
>   - Enhance request factory with `url` and `socket.remoteAddress`.
>   - Update assertions to expect enriched headers (including `referer`, `user-agent`, `x-forwarded-for`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 672c4cd232776fe27c2692a21a550534d553898c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->