### PR TITLE
Added Foundling - Reprise embed to about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -693,7 +693,7 @@ const About = () => {
 								width="100%"
 								height="352"
 								frameBorder="0"
-								allowfullscreen={true}
+								allowFullScreen={true}
 								allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
 								loading="lazy">
 							</iframe>


### PR DESCRIPTION

<img width="821" height="807" alt="image" src="https://github.com/user-attachments/assets/70fd2729-5869-4618-835b-c1251b2d4e78" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds another Spotify embed to the About page’s music list.
> 
> - Inserts a new `iframe` block (`id="Foundling-reprise-embed"`, `data-testid="embed-iframe"`) in `pages/about.js` pointing to `https://open.spotify.com/embed/album/2BciIeBDGtRL3dQVqmCjSH`, matching styling/attributes of existing embeds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 931977d24200c8f2600f89dde982f300f426c0bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->