### PR TITLE
Update vercel and fix path-to-regexp vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
 			"js-yaml": "^4.1.1",
 			"brace-expansion": "^4.0.1",
 			"esbuild": "^0.27.2",
-			"path-to-regexp": "^8.3.0"
+			"path-to-regexp": "^8.3.0",
+			"path-match>path-to-regexp": "^1.0.0"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   brace-expansion: ^4.0.1
   esbuild: ^0.27.2
   path-to-regexp: ^8.3.0
+  path-match>path-to-regexp: ^1.0.0
 
 importers:
 
@@ -3785,6 +3786,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -4248,6 +4252,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -9617,6 +9624,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@0.0.1: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -10025,7 +10034,7 @@ snapshots:
   path-match@1.2.4:
     dependencies:
       http-errors: 1.4.0
-      path-to-regexp: 8.3.0
+      path-to-regexp: 1.9.0
 
   path-parse@1.0.7: {}
 
@@ -10033,6 +10042,10 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
Update vercel to latest (50.3.0) and add override to ensure all path-to-regexp instances use patched version (>=6.3.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade dependencies and enforce security constraints**
> 
> - Bumps `vercel` to `^50.3.0`; `pnpm-lock.yaml` updated with new `@vercel/*` subpackages and transitive deps
> - Raises Node engine in `package.json` to `^24.0.0`
> - Adds `pnpm` overrides to pin `path-to-regexp` to `^8.3.0` and `path-match>path-to-regexp` to `^1.0.0` to ensure patched versions
> - Lockfile reflects dependency graph changes (e.g., updated `@vercel/*`, `typescript` peer usage, and related tooling)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dc975e048d8a0ef6add67ac4da0d6688c0baa4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

> Note: path-match (dev dependency via vercel CLI) uses path-to-regexp@^1.0.0 due to API incompatibility with v6+/v8+. This is a known exception for dev-only tooling and does not affect production security, as all production dependencies use secure versions (>=6.3.0).