### PR TITLE
Adjusted Vercel SpeedInsights samplerate to 0.5 according to documentation to reduce on-demand spend

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -109,7 +109,7 @@ const Sketchplanations = ({ Component, pageProps }) => {
 					<Footer />
 				</div>
 				<Analytics />
-				<SpeedInsights />
+				<SpeedInsights sampleRate={0.5} />
 			</Context.Provider>
 		</PrismicPreview>
 	);


### PR DESCRIPTION
See linked ticket.