### PR TITLE
Added redirect for /projects to github pages

### DIFF
--- a/redirects.mjs
+++ b/redirects.mjs
@@ -40,6 +40,11 @@ export default [
 		permanent: false,
 	},
 	{
+		source: "/projects",
+		destination: "https://jonohey.github.io/sketchplanations-projects/",
+		permanent: true,
+	},
+	{
 		source: "/styleguide",
 		destination: "https://company-208276.frontify.com/d/iATaeFQL51Lv",
 		permanent: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to adding a single static redirect; impact is confined to routing traffic from `/projects` to an external URL.
> 
> **Overview**
> Adds a new **permanent redirect** mapping `GET /projects` to `https://jonohey.github.io/sketchplanations-projects/` in `redirects.mjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3937c8c7f2d2920ee2a17a8e81ec4fe293c87eb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->