### PR TITLE
Changes to make basic download a better size and high-resolution available with payment options.

### DIFF
--- a/components/DownloadModal.js
+++ b/components/DownloadModal.js
@@ -1,10 +1,18 @@
 import { track } from "@vercel/analytics";
-import { Smile, SquareCheckBig } from "lucide-react";
+import classNames from "classnames";
+import { ChevronDown, Download, Smile, SquareCheckBig } from "lucide-react";
 import Link from 'next/link';
+import { useState } from "react";
 
 import styles from "./DownloadModal.module.css";
 
-const DownloadModal = ({ sketchplanationTitle }) => {
+const STRIPE_SUPPORT_10 = "https://buy.stripe.com/5kQ7sL1yZaA6dbX57x1Fe02";
+const STRIPE_SUPPORT_20 = "https://buy.stripe.com/8x27sLcdDaA67RD57x1Fe03";
+const STRIPE_SUPPORT_OTHER = "https://buy.stripe.com/4gMcN57XngYu3Bn6bB1Fe04";
+
+const DownloadModal = ({ sketchplanationTitle, sketchplanationUid }) => {
+	const [highResOpen, setHighResOpen] = useState(false);
+
 	return (
 		<div>
 			<h2 className={styles.header}>
@@ -13,10 +21,91 @@ const DownloadModal = ({ sketchplanationTitle }) => {
 			</h2>
 			<div className={styles.main}>
 				<div className="space-y-6">
+					<p>A sharing-ready image is downloading. Check your downloads folder.</p>
+
+					<div className={styles.highResWrapper}>
+						<button
+							type="button"
+							className={styles.highResTrigger}
+							aria-expanded={highResOpen}
+							aria-controls="high-res-content"
+							onClick={() => {
+								if (!highResOpen) {
+									track('expand_high_res', { sketch: sketchplanationTitle });
+								}
+								setHighResOpen(!highResOpen);
+							}}
+						>
+							Need a high-resolution file?
+							<ChevronDown
+								size={18}
+								className={classNames(
+									styles.highResTriggerIcon,
+									highResOpen && styles.highResTriggerIconOpen
+								)}
+							/>
+						</button>
+
+						{highResOpen && (
+							<div id="high-res-content" className={styles.highResSection}>
+								<p>
+									If it's useful to you, please consider supporting my work.
+								</p>
+								<div className={styles.supportButtons}>
+									<a
+										href={STRIPE_SUPPORT_10}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="btn-primary"
+										aria-label="Support with £10"
+										onClick={() => {
+											track('support_10', { sketch: sketchplanationTitle, location: 'download-modal' });
+										}}
+									>
+										£10
+									</a>
+									<a
+										href={STRIPE_SUPPORT_20}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="btn-primary"
+										aria-label="Support with £20"
+										onClick={() => {
+											track('support_20', { sketch: sketchplanationTitle, location: 'download-modal' });
+										}}
+									>
+										£20
+									</a>
+									<a
+										href={STRIPE_SUPPORT_OTHER}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="btn-primary"
+										aria-label="Support with a custom amount"
+										onClick={() => {
+											track('support_other', { sketch: sketchplanationTitle, location: 'download-modal' });
+										}}
+									>
+										Other
+									</a>
+								</div>
+
+								<a
+									href={`/api/dl?uid=${sketchplanationUid}`}
+									download
+									className={styles.highResCta}
+									onClick={() => {
+										track('download_high_res', { sketch: sketchplanationTitle });
+									}}
+								>
+									<Download size={16} />
+									Download high-resolution
+								</a>
+							</div>
+						)}
+					</div>
+
 					<div>
-						<p className="mb-4">
-							A high-resolution file for <strong>{sketchplanationTitle}</strong> is on its way. Please check your downloads.
-						</p>
 						<p className="mb-2">
 							<Smile size={16} className="inline-block mr-1 -mt-1" />
 							Enjoying the sketches?
@@ -25,7 +114,6 @@ const DownloadModal = ({ sketchplanationTitle }) => {
 							<li>
 								<a
 									href="https://buymeacoffee.com/sketchplanator"
-									className="text-blue-600 hover:underline"
 									target="_blank"
 									rel="noreferrer noopener"
 									onClick={() => {
@@ -38,7 +126,6 @@ const DownloadModal = ({ sketchplanationTitle }) => {
 							<li>
 								<Link
 									href="/big-ideas-little-pictures"
-									className="text-blue-600 hover:underline"
 									target="_blank"
 									onClick={() => {
 										track('Book-page-link', { location: 'download-modal', sketch: sketchplanationTitle });
@@ -50,7 +137,6 @@ const DownloadModal = ({ sketchplanationTitle }) => {
 							<li>
 								<Link
 									href="/subscribe"
-									className="text-blue-600 hover:underline"
 									target="_blank"
 									rel="noreferrer noopener"
 									onClick={() => {
@@ -61,21 +147,21 @@ const DownloadModal = ({ sketchplanationTitle }) => {
 								</Link>
 							</li>
 						</ul>
-						<p>
-							Commercial usage? Please see the{" "}
-							<Link
-								href="/licence"
-								target="_blank"
-								rel="noreferrer"
-								className="text-blue-600 hover:underline"
-								onClick={() => {
-									track('Licence-page-link', { location: 'download-modal', sketch: sketchplanationTitle });
-								}}
-							>
-								licence
-							</Link>
-						</p>
 					</div>
+
+					<p>
+						Commercial usage? Please see the{" "}
+						<Link
+							href="/licence"
+							target="_blank"
+							rel="noreferrer"
+							onClick={() => {
+								track('Licence-page-link', { location: 'download-modal', sketch: sketchplanationTitle });
+							}}
+						>
+							licence
+						</Link>
+					</p>
 				</div>
 			</div>
 		</div>

--- a/components/DownloadModal.module.css
+++ b/components/DownloadModal.module.css
@@ -7,17 +7,37 @@
 }
 
 .main a {
-  @apply text-blue;
+  @apply text-blue dark:text-blueLight;
 }
 
-.main button a {
-  @apply text-white;
+.highResWrapper {
+  @apply rounded border border-border overflow-hidden;
 }
 
-.form {
-  @apply -m-2 mt-3;
+.highResTrigger {
+  @apply w-full flex items-center justify-between gap-x-2 py-3 px-4 text-text text-left cursor-pointer hover:bg-bgDarker transition-colors;
 }
 
-.form :global(> *) {
-  @apply p-2;
+.highResTriggerIcon {
+  @apply flex-shrink-0 transition-transform duration-200;
+}
+
+.highResTriggerIconOpen {
+  @apply rotate-180;
+}
+
+.highResSection {
+  @apply space-y-3 px-4 pb-4 pt-3 border-t border-border bg-bgHighlight;
+}
+
+.supportButtons {
+  @apply flex flex-wrap gap-2;
+}
+
+.supportButtons a {
+  @apply text-white min-w-[4rem] text-center;
+}
+
+.highResCta {
+  @apply flex items-center justify-center gap-x-2 w-full py-2 px-4 rounded border border-border bg-bg text-blue dark:text-blueLight text-sm font-semibold hover:bg-bgDarker transition-colors;
 }

--- a/components/SketchplanationCtas.js
+++ b/components/SketchplanationCtas.js
@@ -58,7 +58,7 @@ const SketchplanationCtas = ({
 					variant === "lightbox" && styles.ctaLightbox,
 					variant === "lightbox" ? styles.ctaHoverLightbox : styles.ctaHover
 				)}
-				href={`/api/dl?uid=${sketchplanationUid}`}
+				href={`/api/dl?uid=${sketchplanationUid}&format=medium`}
 				download
 				onClick={() => {
 					track("Sketch-link-download", { sketch: `${title}` });

--- a/pages/[uid].js
+++ b/pages/[uid].js
@@ -201,6 +201,7 @@ const SketchplanationPage = ({
 			<Modal isOpen={downloadModalOpen} onClose={() => setDownloadModalOpen(false)}>
 				<DownloadModal
 					sketchplanationTitle={title}
+					sketchplanationUid={uid}
 				/>
 			</Modal>
 

--- a/pages/api/dl.js
+++ b/pages/api/dl.js
@@ -2,15 +2,29 @@ import fetch from "node-fetch";
 
 import { client } from "services/prismic";
 
+const sanitizeSlug = (slug) =>
+	slug.replace(/[^a-z0-9-]/gi, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase();
+
 export default async (req, res) => {
 	const uid = req.query.uid;
+	const format = req.query.format;
 	const sketchplanation = await client.getByUID("sketchplanation", uid, {
 		fetch: "sketchplanation.image",
 	});
 
-	const imageUrl = sketchplanation.data.image.url.split("?")[0];
-	const extension = imageUrl.split(".").pop().toLowerCase();
-	const filename = `sketchplanations-${uid}.${extension}`;
+	const baseUrl = sketchplanation.data.image.url.split("?")[0];
+	const extension = baseUrl.split(".").pop().toLowerCase();
+	const safeSlug = sanitizeSlug(uid);
+
+	let imageUrl, filename;
+
+	if (format === "medium") {
+		imageUrl = `${baseUrl}?auto=format,compress&fit=max&w=1920&h=1920`;
+		filename = `sketchplanations-${safeSlug}.${extension}`;
+	} else {
+		imageUrl = baseUrl;
+		filename = `sketchplanations-${safeSlug}-high-resolution.${extension}`;
+	}
 
 	res.setHeader("content-disposition", "attachment; filename=" + filename);
 	res.setHeader("X-Robots-Tag", "noindex");


### PR DESCRIPTION
This should make the download better for everyone by giving them a sensible-sized file, and surface payment options for people who are only really using it for something valuable—or why would you need a high-resolution file.

After:
<img width="648" height="505" alt="image" src="https://github.com/user-attachments/assets/d28895fe-c530-4e13-bdfa-aa5019157696" />

<img width="614" height="605" alt="image" src="https://github.com/user-attachments/assets/3592f3c5-4e96-472f-9e39-844764cef848" />

Find Stripe pages in Payment Links

Before:

<img width="661" height="446" alt="image" src="https://github.com/user-attachments/assets/be3c1f8d-f53f-4869-8cef-1a1e81b2abc7" />
