### PR TITLE
Adjusted wording on download

### DIFF
--- a/components/DownloadModal.js
+++ b/components/DownloadModal.js
@@ -49,7 +49,7 @@ const DownloadModal = ({ sketchplanationTitle, sketchplanationUid }) => {
 						{highResOpen && (
 							<div id="high-res-content" className={styles.highResSection}>
 								<p>
-									If it's useful to you, please consider supporting my work.
+									If this download is useful, a contribution is welcome.
 								</p>
 								<div className={styles.supportButtons}>
 									<a


### PR DESCRIPTION
If this download is useful, a contribution is welcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change in the download modal; no logic, tracking, or payment link behavior is modified.
> 
> **Overview**
> Updates the support/contribution message shown in `DownloadModal` when the high-resolution download section is expanded, changing the wording to "If this download is useful, a contribution is welcome."
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 965167d26583d54d6417c77534158b276599a1ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->