### PR TITLE
Prevent single-key shortcuts from hijacking Ctrl+F / Cmd+F

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -11,6 +11,7 @@ import styles from "./Header.module.css";
 
 import GradientBlur from "components/GradientBlur";
 import Navigation from "components/Navigation";
+import shouldIgnoreShortcut from "helpers/shouldIgnoreShortcut";
 import useSearch from "hooks/useSearch";
 
 import Context from "context";
@@ -29,16 +30,19 @@ const Header = () => {
 	};
 
 	useHotkeys("/", (e) => {
+		if (shouldIgnoreShortcut(e)) return;
 		e.preventDefault();
 		enterSearch();
 	}, { useKey: true });
 
 	useHotkeys("f", (e) => {
+		if (shouldIgnoreShortcut(e)) return;
 		e.preventDefault();
 		enterSearch();
 	}, { useKey: true });
 
 	useHotkeys("s", (e) => {
+		if (shouldIgnoreShortcut(e)) return;
 		e.preventDefault();
 		enterSearch();
 	}, { useKey: true });

--- a/components/PrevNextSketchplanation.js
+++ b/components/PrevNextSketchplanation.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import shouldIgnoreShortcut from "helpers/shouldIgnoreShortcut";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -11,8 +12,10 @@ const PrevNextSketchplanation = ({ sketchplanation, kind }) => {
 	const secondaryKeyboardKey = kind === "next" ? "left" : "right";
 	const router = useRouter();
 
-	const navigate = () =>
+	const navigate = (e) => {
+		if (shouldIgnoreShortcut(e)) return;
 		sketchplanation?.uid && router.push(`/${sketchplanation.uid}`);
+	};
 
 	useHotkeys(keyboardKey, navigate, {}, [sketchplanation]);
 	useHotkeys(secondaryKeyboardKey, navigate, {}, [sketchplanation]);

--- a/components/SearchForm.js
+++ b/components/SearchForm.js
@@ -7,6 +7,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import styles from "./SearchForm.module.css";
 
 import { isPresent } from "helpers";
+import shouldIgnoreShortcut from "helpers/shouldIgnoreShortcut";
 import KeyboardShortcut from "./KeyboardShortcut";
 
 const SearchForm = ({
@@ -25,6 +26,7 @@ const SearchForm = ({
 	};
 
 	const focusInput = (e) => {
+		if (shouldIgnoreShortcut(e)) return;
 		if (router.pathname === "/search") {
 			e.preventDefault();
 			inputRef.current?.focus();

--- a/helpers/shouldIgnoreShortcut.js
+++ b/helpers/shouldIgnoreShortcut.js
@@ -1,0 +1,16 @@
+export default function shouldIgnoreShortcut(e) {
+	if (e.repeat) return true;
+	if (e.ctrlKey || e.metaKey || e.altKey) return true;
+
+	const tag = e.target?.tagName;
+	if (
+		tag === "INPUT" ||
+		tag === "TEXTAREA" ||
+		tag === "SELECT" ||
+		e.target?.isContentEditable
+	) {
+		return true;
+	}
+
+	return false;
+}

--- a/pages/[uid].js
+++ b/pages/[uid].js
@@ -13,6 +13,7 @@ import SketchplanationsStack from "components/SketchplanationsStack";
 import SubscribeInline from "components/SubscribeInline";
 import TaggedSketchplanations from "components/TaggedSketchplanations";
 import { humanizePublishedDate, isPresent, pageTitle, shuffle } from "helpers";
+import shouldIgnoreShortcut from "helpers/shouldIgnoreShortcut";
 import { useRandomHandle } from "hooks/useRandomHandle";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { ImageJsonLd } from "next-seo";
@@ -111,7 +112,8 @@ const SketchplanationPage = ({
 
 	useHotkeys(
 		"right, k",
-		() => {
+		(e) => {
+			if (shouldIgnoreShortcut(e)) return;
 			if (olderUid) {
 				router.push(`/${olderUid}`);
 			}
@@ -122,7 +124,8 @@ const SketchplanationPage = ({
 
 	useHotkeys(
 		"left, j",
-		() => {
+		(e) => {
+			if (shouldIgnoreShortcut(e)) return;
 			if (newerUid) {
 				router.push(`/${newerUid}`);
 			}
@@ -133,7 +136,8 @@ const SketchplanationPage = ({
 
 	useHotkeys(
 		"r",
-		() => {
+		(e) => {
+			if (shouldIgnoreShortcut(e)) return;
 			if (randomHandle) {
 				router.push(`/${randomHandle}`);
 			}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Tests
+
+Tests use [Vitest](https://vitest.dev/). Configuration is in `vitest.config.mjs` at the project root.
+
+```bash
+pnpm test              # run all tests once
+pnpm vitest            # watch mode
+pnpm vitest path/to/file.test.js  # run a specific file
+```

--- a/tests/helpers/shouldIgnoreShortcut.test.js
+++ b/tests/helpers/shouldIgnoreShortcut.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import shouldIgnoreShortcut from "../../helpers/shouldIgnoreShortcut";
+
+const makeEvent = (overrides = {}) => ({
+	repeat: false,
+	ctrlKey: false,
+	metaKey: false,
+	altKey: false,
+	shiftKey: false,
+	target: { tagName: "DIV", isContentEditable: false },
+	...overrides,
+});
+
+describe("shouldIgnoreShortcut", () => {
+	it("returns false for a plain key press", () => {
+		expect(shouldIgnoreShortcut(makeEvent())).toBe(false);
+	});
+
+	it("returns true when ctrlKey is held", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ ctrlKey: true }))).toBe(true);
+	});
+
+	it("returns true when metaKey (Cmd) is held", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ metaKey: true }))).toBe(true);
+	});
+
+	it("returns true when altKey is held", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ altKey: true }))).toBe(true);
+	});
+
+	it("returns false when only shiftKey is held", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ shiftKey: true }))).toBe(false);
+	});
+
+	it("returns true for repeated keydown events", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ repeat: true }))).toBe(true);
+	});
+
+	it("returns true when target is an INPUT", () => {
+		expect(
+			shouldIgnoreShortcut(makeEvent({ target: { tagName: "INPUT" } })),
+		).toBe(true);
+	});
+
+	it("returns true when target is a TEXTAREA", () => {
+		expect(
+			shouldIgnoreShortcut(makeEvent({ target: { tagName: "TEXTAREA" } })),
+		).toBe(true);
+	});
+
+	it("returns true when target is a SELECT", () => {
+		expect(
+			shouldIgnoreShortcut(makeEvent({ target: { tagName: "SELECT" } })),
+		).toBe(true);
+	});
+
+	it("returns true when target is contentEditable", () => {
+		expect(
+			shouldIgnoreShortcut(
+				makeEvent({ target: { tagName: "DIV", isContentEditable: true } }),
+			),
+		).toBe(true);
+	});
+
+	it("returns false when target is a non-input element", () => {
+		expect(
+			shouldIgnoreShortcut(makeEvent({ target: { tagName: "BUTTON" } })),
+		).toBe(false);
+	});
+
+	it("handles missing target gracefully", () => {
+		expect(shouldIgnoreShortcut(makeEvent({ target: null }))).toBe(false);
+	});
+});


### PR DESCRIPTION
Single-key shortcuts (F, S, /, J, K, R) were intercepting browser shortcuts like Ctrl+F / Cmd+F (Find on Page) and Ctrl+R (Reload). This adds a shouldIgnoreShortcut guard function that lets modifier-key combos pass through to the browser. The guard also prevents shortcuts from firing during key repeat or when typing in form inputs. Includes unit tests for the guard logic.

Also added test for it and readme for how to run the tests.

#683 