### PR TITLE
Replace homepage grid with category carousels

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,5 +1,6 @@
 import { track } from '@vercel/analytics';
 import { ChevronRight, ExternalLink } from "lucide-react";
+import { useRouter } from "next/router";
 import { RoughNotation } from "react-rough-notation";
 import { Cards } from "./Cards";
 import FancyLink from "./FancyLink";
@@ -117,38 +118,43 @@ const categories = [
 ];
 
 const Footer = () => {
+	const { pathname } = useRouter();
+	const isHome = pathname === "/";
+
 	return (
 		<footer className={styles.root}>
-			<div id="footer-categories" className="pt-6 sm:pt-10 px-[var(--edgeInset)]">
-				<div className="max-w-screen-xl mx-auto">
-					<div className="mb-3 text-xl font-semibold">Explore more</div>
-					<div className="prose mb-6">
-						<p className="text-balance">
-							The sketches cover many topics. Here are some of my favourites:
-						</p>
+			{!isHome && (
+				<div id="footer-categories" className="pt-6 sm:pt-10 px-[var(--edgeInset)]">
+					<div className="max-w-screen-xl mx-auto">
+						<div className="mb-3 text-xl font-semibold">Explore more</div>
+						<div className="prose mb-6">
+							<p className="text-balance">
+								The sketches cover many topics. Here are some of my favourites:
+							</p>
+						</div>
+						<div className="columns-2 md:columns-3 lg:columns-5 -my-1">
+							{categories.map(({ title, uid }) => {
+								return (
+									<div key={uid} className="block break-inside-avoid py-1">
+										<FancyLink href={`/categories/${uid}`}>{title}</FancyLink>
+									</div>
+								);
+							})}
+						</div>
+						<FancyLink
+							href="/categories"
+							className="inline-block hover:text-blue mt-6"
+						>
+							<span className="inline-flex flex-row gap-x-1 items-center">
+								More topics
+								<ChevronRight size={16} />
+							</span>
+						</FancyLink>
 					</div>
-					<div className="columns-2 md:columns-3 lg:columns-5 -my-1">
-						{categories.map(({ title, uid }) => {
-							return (
-								<div key={uid} className="block break-inside-avoid py-1">
-									<FancyLink href={`/categories/${uid}`}>{title}</FancyLink>
-								</div>
-							);
-						})}
-					</div>
-					<FancyLink
-						href="/categories"
-						className="inline-block hover:text-blue mt-6"
-					>
-						<span className="inline-flex flex-row gap-x-1 items-center">
-							More topics
-							<ChevronRight size={16} />
-						</span>
-					</FancyLink>
 				</div>
-			</div>
+			)}
 
-			<div id="footer-subscribe-inline" className="border-t border-borderFooter pt-6 sm:pt-10 px-[var(--edgeInset)]">
+			<div id="footer-subscribe-inline" className={`${isHome ? "" : "border-t border-borderFooter "}pt-6 sm:pt-10 px-[var(--edgeInset)]`}>
 				<div className="grid sm:grid-cols-2 gap-12 max-w-screen-xl mx-auto items-center">
 					<Cards />
 					<div className="grid gap-y-8 items-start">

--- a/components/HomeCategoryCarousel.js
+++ b/components/HomeCategoryCarousel.js
@@ -1,0 +1,417 @@
+import { track } from "@vercel/analytics";
+import { PrismicNextImage } from "@prismicio/next";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import FancyLink from "components/FancyLink";
+import { humanizePublishedDate } from "helpers";
+import styles from "./HomeCategoryCarousel.module.css";
+
+const SCROLL_DEBOUNCE_MS = 220;
+
+function useCarouselScrollTracking(categoryLabel, scrollRef) {
+	const reportedRef = useRef(false);
+	const debounceRef = useRef(null);
+
+	const reportScroll = useCallback(() => {
+		if (reportedRef.current) return;
+		reportedRef.current = true;
+		track("homepage_carousel_scroll", { category: categoryLabel });
+	}, [categoryLabel]);
+
+	const onScroll = useCallback(() => {
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+		debounceRef.current = setTimeout(() => {
+			const el = scrollRef.current;
+			if (el && el.scrollLeft > 2) {
+				reportScroll();
+			}
+		}, SCROLL_DEBOUNCE_MS);
+	}, [scrollRef, reportScroll]);
+
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, []);
+
+	return { onScroll, reportScroll };
+}
+
+const SKELETON_CARD_COUNT = 8;
+
+function CarouselRowSkeleton({
+	label,
+	viewAllHref,
+	headingId,
+	sectionId,
+	headingAs: HeadingTag,
+}) {
+	return (
+		<section
+			className={styles.section}
+			aria-labelledby={headingId}
+			id={sectionId}
+		>
+			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+				<div className={styles.header}>
+					<HeadingTag
+						className={`${styles.title} ${
+							HeadingTag === "h3" ? styles.titleH3 : styles.titleH2
+						}`}
+						id={headingId}
+					>
+						<Link href={viewAllHref} className={styles.titleLink}>
+							{label}
+						</Link>
+					</HeadingTag>
+				</div>
+			</div>
+			<div className={styles.trackOuter}>
+				<div
+					className={`${styles.track} ${styles.skeletonTrack}`}
+					aria-hidden="true"
+				>
+					{Array.from({ length: SKELETON_CARD_COUNT }).map((_, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: placeholder cards are static
+						<div key={i} className={styles.card}>
+							<span className={`${styles.imageWrap} ${styles.skeletonShimmer}`} />
+							<span className={styles.skeletonTitle} />
+						</div>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function HomeCategoryCarouselRow({
+	label,
+	viewAllHref,
+	sketches,
+	category: categoryLabel,
+	headingId,
+	sectionId,
+	headingAs: HeadingTag = "h2",
+	priorityImage = false,
+	showPublishedDate = false,
+	deferMount = false,
+	prefetchCards = false,
+}) {
+	const router = useRouter();
+	const scrollRef = useRef(null);
+	const scrollFrameRef = useRef(null);
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+	const [canNavigate, setCanNavigate] = useState(false);
+	const [isMounted, setIsMounted] = useState(!deferMount);
+	const { onScroll, reportScroll } = useCarouselScrollTracking(
+		categoryLabel,
+		scrollRef,
+	);
+
+	const updateScrollState = useCallback(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		const { scrollLeft, scrollWidth, clientWidth } = el;
+		const overflow = scrollWidth > clientWidth + 1;
+		setCanNavigate(overflow);
+		setCanScrollLeft(scrollLeft > 2);
+		setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
+	}, []);
+
+	const scheduleUpdateScrollState = useCallback(() => {
+		if (scrollFrameRef.current != null) return;
+		scrollFrameRef.current = window.requestAnimationFrame(() => {
+			scrollFrameRef.current = null;
+			updateScrollState();
+		});
+	}, [updateScrollState]);
+
+	useEffect(
+		() => () => {
+			if (scrollFrameRef.current != null) {
+				window.cancelAnimationFrame(scrollFrameRef.current);
+				scrollFrameRef.current = null;
+			}
+		},
+		[],
+	);
+
+	useEffect(() => {
+		if (!deferMount || isMounted) return undefined;
+
+		let cancelled = false;
+		let idleHandle = null;
+		let timeoutHandle = null;
+
+		const activate = () => {
+			if (cancelled) return;
+			const flip = () => {
+				if (!cancelled) setIsMounted(true);
+			};
+			if (typeof window.requestIdleCallback === "function") {
+				idleHandle = window.requestIdleCallback(flip, { timeout: 2000 });
+			} else {
+				timeoutHandle = window.setTimeout(flip, 200);
+			}
+		};
+
+		if (document.readyState === "complete") {
+			activate();
+		} else {
+			window.addEventListener("load", activate, { once: true });
+		}
+
+		return () => {
+			cancelled = true;
+			window.removeEventListener("load", activate);
+			if (idleHandle && typeof window.cancelIdleCallback === "function") {
+				window.cancelIdleCallback(idleHandle);
+			}
+			if (timeoutHandle) window.clearTimeout(timeoutHandle);
+		};
+	}, [deferMount, isMounted]);
+
+	useEffect(() => {
+		if (!isMounted) return undefined;
+		const el = scrollRef.current;
+		if (!el) return undefined;
+		updateScrollState();
+		const ro = new ResizeObserver(scheduleUpdateScrollState);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [updateScrollState, scheduleUpdateScrollState, sketches, isMounted]);
+
+	const scrollByDirection = (direction) => {
+		const el = scrollRef.current;
+		if (!el) return;
+		reportScroll();
+		const delta = Math.round(el.clientWidth * 0.85) * direction;
+		el.scrollBy({ left: delta, behavior: "smooth" });
+	};
+
+	if (!isMounted) {
+		return (
+			<CarouselRowSkeleton
+				label={label}
+				viewAllHref={viewAllHref}
+				headingId={headingId}
+				sectionId={sectionId}
+				headingAs={HeadingTag}
+			/>
+		);
+	}
+
+	return (
+		<section
+			className={styles.section}
+			aria-labelledby={headingId}
+			id={sectionId}
+		>
+			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+				<div className={styles.header}>
+					<HeadingTag
+						className={`${styles.title} ${
+							HeadingTag === "h3" ? styles.titleH3 : styles.titleH2
+						}`}
+						id={headingId}
+					>
+						<Link
+							href={viewAllHref}
+							className={styles.titleLink}
+							onClick={() =>
+								track("homepage_carousel_view_all_click", {
+									category: categoryLabel,
+								})
+							}
+						>
+							{label}
+						</Link>
+					</HeadingTag>
+				</div>
+			</div>
+
+			<div className={styles.trackOuter}>
+				{canNavigate && canScrollLeft && (
+					<span className={`${styles.fade} ${styles.fadeLeft}`} aria-hidden="true" />
+				)}
+				{canNavigate && canScrollRight && (
+					<span className={`${styles.fade} ${styles.fadeRight}`} aria-hidden="true" />
+				)}
+				{canNavigate && canScrollLeft && (
+					<button
+						type="button"
+						className={`${styles.arrow} ${styles.arrowLeft}`}
+						aria-label="Scroll left"
+						onClick={() => scrollByDirection(-1)}
+					>
+						<ChevronLeft size={20} strokeWidth={2} />
+					</button>
+				)}
+				<div
+					ref={scrollRef}
+					className={styles.track}
+					onScroll={() => {
+						onScroll();
+						scheduleUpdateScrollState();
+					}}
+				>
+					{sketches.map((sketch, index) => {
+						const sketchHref = `/${sketch.uid}`;
+						const prefetchOnIntent = prefetchCards
+							? undefined
+							: () => router.prefetch(sketchHref);
+						return (
+							<Link
+								key={sketch.uid}
+								href={sketchHref}
+								className={styles.card}
+								target="_blank"
+								rel="noopener"
+								prefetch={prefetchCards ? undefined : false}
+								onMouseEnter={prefetchOnIntent}
+								onFocus={prefetchOnIntent}
+								onTouchStart={prefetchOnIntent}
+								onClick={() =>
+									track("homepage_carousel_sketch_click", {
+										category: categoryLabel,
+										sketch_title: sketch.title,
+									})
+								}
+							>
+								<span className={styles.imageWrap}>
+									<PrismicNextImage
+										field={sketch.image}
+										className={styles.image}
+										fill
+										sizes="(max-width: 639px) min(15rem, calc(100vw - 4.5rem)), (max-width: 767px) 11rem, (max-width: 1023px) 12rem, 13rem"
+										priority={priorityImage && index === 0}
+										loading={
+											priorityImage && index === 0
+												? undefined
+												: deferMount
+													? "eager"
+													: "lazy"
+										}
+										fetchPriority={deferMount ? "low" : undefined}
+										imgixParams={{
+											fit: "crop",
+											crop: "top",
+											ar: "1:1",
+										}}
+										fallbackAlt=""
+									/>
+								</span>
+								<span className={styles.cardTitle}>{sketch.title}</span>
+								{showPublishedDate && sketch.publishedAt && (
+									<time
+										className={styles.cardDate}
+										dateTime={sketch.publishedAt}
+									>
+										{humanizePublishedDate(sketch.publishedAt)}
+									</time>
+								)}
+								<span className="sr-only"> (opens in new tab)</span>
+							</Link>
+						);
+					})}
+					<Link
+						href={viewAllHref}
+						className={styles.viewAllCard}
+						onClick={() =>
+							track("homepage_carousel_view_all_click", {
+								category: categoryLabel,
+							})
+						}
+					>
+						<span className={styles.viewAllCardInner}>
+							<span className={styles.viewAllCardLabel}>
+								View all
+								<ChevronRight size={16} strokeWidth={2} />
+							</span>
+						</span>
+					</Link>
+				</div>
+				{canNavigate && (
+					<button
+						type="button"
+						className={`${styles.arrow} ${styles.arrowRight}`}
+						aria-label="Scroll right"
+						disabled={!canScrollRight}
+						onClick={() => scrollByDirection(1)}
+					>
+						<ChevronRight size={20} strokeWidth={2} />
+					</button>
+				)}
+			</div>
+		</section>
+	);
+}
+
+export default function HomeCategoryCarousels({ rows, interlude = null }) {
+	if (!rows?.length) return null;
+
+	const recentRows = rows.filter((row) => row.kind === "recent");
+	const categoryRows = rows.filter((row) => row.kind === "category");
+
+	return (
+		<div id="home-category-carousels">
+			{recentRows.map((row, index) => (
+				<HomeCategoryCarouselRow
+					key="recent"
+					label={row.label}
+					viewAllHref={row.viewAllHref}
+					sketches={row.sketches}
+					category={row.label}
+					headingId="carousel-heading-recent"
+					sectionId="recent-sketches"
+					headingAs="h2"
+					priorityImage={index === 0}
+					showPublishedDate
+					prefetchCards
+				/>
+			))}
+
+			{interlude}
+
+			{categoryRows.length > 0 && (
+				<section
+					className={styles.groupSection}
+					aria-labelledby="carousel-group-explore"
+				>
+					<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+						<h2 id="carousel-group-explore" className={styles.groupHeading}>
+							Explore visuals for
+						</h2>
+					</div>
+					{categoryRows.map((row) => (
+						<HomeCategoryCarouselRow
+							key={row.slug}
+							label={row.label}
+							viewAllHref={row.viewAllHref}
+							sketches={row.sketches}
+							category={row.label}
+							headingId={`carousel-heading-${row.slug}`}
+							headingAs="h3"
+							deferMount
+						/>
+					))}
+					<div className={`container mx-auto px-4 sm:px-6 lg:px-8 ${styles.andMoreWrap}`}>
+						<FancyLink
+							href="/search"
+							className={styles.andMoreLink}
+							onClick={() =>
+								track("homepage_carousel_and_more_click")
+							}
+						>
+							…and many more
+						</FancyLink>
+					</div>
+				</section>
+			)}
+		</div>
+	);
+}

--- a/components/HomeCategoryCarousel.module.css
+++ b/components/HomeCategoryCarousel.module.css
@@ -1,0 +1,230 @@
+.section {
+  @apply mb-3 sm:mb-4;
+}
+
+.groupSection {
+  @apply mt-4 sm:mt-8;
+}
+
+.groupHeading {
+  @apply text-2xl sm:text-3xl font-bold text-text mb-6 sm:mb-8;
+}
+
+.andMoreWrap {
+  @apply mt-4 mb-8 sm:mt-6 sm:mb-12 flex justify-center;
+}
+
+.andMoreLink {
+  @apply text-base sm:text-lg font-semibold;
+}
+
+.header {
+  @apply flex items-baseline justify-between gap-4 mb-2 sm:mb-3;
+}
+
+.title {
+  @apply font-bold text-text m-0;
+  font-family: inherit;
+}
+
+.titleH2 {
+  @apply text-xl sm:text-2xl;
+}
+
+.titleH3 {
+  @apply text-lg sm:text-xl;
+}
+
+.titleLink {
+  @apply text-inherit no-underline hover:text-blue transition-colors;
+}
+
+.trackOuter {
+  @apply relative;
+
+  --track-inset: 1rem;
+}
+
+@screen sm {
+  .trackOuter {
+    --track-inset: max(1.5rem, calc((100vw - 640px) / 2 + 1.5rem));
+  }
+}
+
+@screen md {
+  .trackOuter {
+    --track-inset: max(1.5rem, calc((100vw - 768px) / 2 + 1.5rem));
+  }
+}
+
+@screen lg {
+  .trackOuter {
+    --track-inset: max(2rem, calc((100vw - 1024px) / 2 + 2rem));
+  }
+}
+
+@screen xl {
+  .trackOuter {
+    --track-inset: max(2rem, calc((100vw - 1280px) / 2 + 2rem));
+  }
+}
+
+.fade {
+  @apply hidden md:block absolute top-0 bottom-0 pointer-events-none z-10 transition-opacity duration-200;
+}
+
+.fadeLeft {
+  left: 0;
+  width: calc(var(--track-inset) + 1.5rem);
+  background: linear-gradient(to right, var(--color-bg), hsla(var(--color-bgHsl), 0));
+}
+
+.fadeRight {
+  right: 0;
+  width: 3.5rem;
+  background: linear-gradient(to left, var(--color-bg), hsla(var(--color-bgHsl), 0));
+}
+
+.track {
+  @apply flex gap-2 sm:gap-3 overflow-x-auto scroll-smooth pb-2;
+
+  padding-left: var(--track-inset);
+  scroll-padding-inline-start: var(--track-inset);
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
+}
+
+.track::-webkit-scrollbar {
+  display: none;
+}
+
+.arrow {
+  @apply hidden md:flex absolute z-20 items-center justify-center w-9 h-9 rounded-full border border-border bg-bg shadow-sm text-text hover:bg-bgDarker transition-opacity duration-200;
+  top: 5rem;
+  opacity: 0;
+}
+
+.trackOuter:hover .arrow,
+.arrow:focus-visible {
+  opacity: 1;
+}
+
+@screen sm {
+  .arrow {
+    top: 5.5rem;
+  }
+}
+
+@screen md {
+  .arrow {
+    top: 6rem;
+  }
+}
+
+@screen lg {
+  .arrow {
+    top: 6.75rem;
+  }
+}
+
+.arrowLeft {
+  left: 0.5rem;
+}
+
+.arrowRight {
+  right: 0.5rem;
+}
+
+@screen lg {
+  .arrowLeft {
+    left: 1rem;
+  }
+
+  .arrowRight {
+    right: 1rem;
+  }
+}
+
+.arrow:disabled {
+  @apply opacity-30 pointer-events-none;
+}
+
+.card {
+  @apply flex-none w-[min(15rem,calc(100vw-4.5rem))] sm:w-44 md:w-48 lg:w-52 snap-start block no-underline text-text;
+}
+
+.imageWrap {
+  @apply relative block w-full aspect-square rounded-lg overflow-hidden bg-paper;
+
+  box-shadow: 0 2.3rem 1rem -2rem var(--color-sketchShadow);
+
+  &::before {
+    content: '';
+    @apply absolute inset-0 pointer-events-none z-10 rounded-lg;
+
+    box-shadow: inset 0 0 0 1px hsla(0, 0%, 0%, 0.06);
+    mix-blend-mode: multiply;
+  }
+}
+
+@media (pointer: fine) {
+  .imageWrap {
+    @apply transition-transform duration-200;
+
+    transform-origin: center top;
+  }
+
+  .card:hover .imageWrap {
+    transform: translateY(-2px) scale(1.03);
+
+    box-shadow: 0 2.8rem 1rem -2.25rem var(--color-sketchShadowHover);
+  }
+}
+
+.image {
+  @apply object-cover object-top;
+}
+
+.cardTitle {
+  @apply block mt-3 text-sm leading-snug text-text line-clamp-2 transition-colors;
+}
+
+.card:hover .cardTitle {
+  @apply text-blue;
+}
+
+.cardDate {
+  @apply block mt-1 text-xs text-textSubdued;
+}
+
+.viewAllCard {
+  @apply flex-none w-[min(15rem,calc(100vw-4.5rem))] sm:w-44 md:w-48 lg:w-52 snap-start block no-underline;
+}
+
+.viewAllCardInner {
+  @apply flex items-center justify-center w-full aspect-square rounded-lg border-2 border-dashed border-border bg-bgHighlight text-blue text-center transition-colors;
+}
+
+.viewAllCard:hover .viewAllCardInner {
+  @apply border-blue;
+}
+
+.viewAllCardLabel {
+  @apply inline-flex items-center gap-1 text-sm font-semibold;
+}
+
+.skeletonTrack {
+  @apply overflow-x-hidden;
+}
+
+.skeletonShimmer {
+  @apply bg-bgHighlight animate-pulse;
+}
+
+.skeletonTitle {
+  @apply block mt-3 rounded-sm bg-bgHighlight animate-pulse;
+
+  height: 2.25rem;
+  width: 85%;
+}

--- a/helpers/getTagDocumentBySlug.js
+++ b/helpers/getTagDocumentBySlug.js
@@ -1,0 +1,23 @@
+import * as prismic from "@prismicio/client";
+
+import { client } from "services/prismic";
+
+/**
+ * Resolves a tag document from a URL slug (same rules as pages/categories/[tag].js).
+ */
+export async function getTagDocumentBySlug(slug) {
+	const tagIdentifer = slug.replace(/-/g, " ");
+	let tagDocs = await client.get({
+		filters: [prismic.filter.at("my.tag.identifier", tagIdentifer)],
+		pageSize: 1,
+	});
+
+	if (tagDocs.total_results_size === 0) {
+		tagDocs = await client.get({
+			filters: [prismic.filter.at("my.tag.identifier", slug)],
+			pageSize: 1,
+		});
+	}
+
+	return tagDocs?.results?.[0] ?? null;
+}

--- a/helpers/homeCarouselCategories.js
+++ b/helpers/homeCarouselCategories.js
@@ -1,0 +1,19 @@
+/** Homepage carousels — audience rows first, then topic rows. */
+export const HOME_CAROUSEL_CATEGORIES = [
+	{ slug: "learning", label: "Teachers" },
+	{ slug: "management", label: "Managers & Leaders" },
+	{ slug: "writing", label: "Writers" },
+	{ slug: "software", label: "Developers" },
+	{ slug: "entrepreneurship", label: "Entrepreneurs" },
+	{ slug: "product-management", label: "Product managers" },
+	{ slug: "parenting", label: "Parents" },
+	{ slug: "data", label: "Data scientists" },
+	{ slug: "marketing", label: "Marketers" },
+	{ slug: "design", label: "Designers" },
+	{ slug: "wellbeing", label: "Wellbeing" },
+	{ slug: "psychology", label: "Psychology" },
+	{ slug: "science", label: "Science" },
+	{ slug: "productivity", label: "Productivity" },
+	{ slug: "motivation", label: "Motivation" },
+	{ slug: "geography", label: "Geography" },
+];

--- a/hooks/useSearch.js
+++ b/hooks/useSearch.js
@@ -29,7 +29,30 @@ const useSearch = () => {
 	const debouncedSearchQuery = useDebouncedValue(query, 500);
 
 	useEffect(() => {
-		fetchIntialResults().then(setInitialResults);
+		let cancelled = false;
+		let idleHandle = null;
+		let timeoutHandle = null;
+
+		const load = () => {
+			if (cancelled) return;
+			fetchIntialResults().then((results) => {
+				if (!cancelled) setInitialResults(results);
+			});
+		};
+
+		if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+			idleHandle = window.requestIdleCallback(load, { timeout: 3000 });
+		} else {
+			timeoutHandle = window.setTimeout(load, 1000);
+		}
+
+		return () => {
+			cancelled = true;
+			if (idleHandle != null && typeof window.cancelIdleCallback === "function") {
+				window.cancelIdleCallback(idleHandle);
+			}
+			if (timeoutHandle != null) window.clearTimeout(timeoutHandle);
+		};
 	}, []);
 
 	const setQuery = (query) => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,7 @@ const nextConfig = {
 				hostname: "images.prismic.io",
 			},
 		],
+		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384, 448, 512],
 		// loader: "custom",
 		// loaderFile: "./loader.js",
 	},

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -45,12 +45,6 @@ class MyDocument extends Document {
 					<meta key="og:title" property="og:title" content={pageTitle()} />
 					<meta property="og:site_name" content="Sketchplanations" />
 					<meta name="twitter:site" content="@sketchplanator" />
-					<link rel="preconnect" href="https://fonts.googleapis.com" />
-					<link
-						rel="preconnect"
-						href="https://fonts.gstatic.com"
-						crossOrigin="true"
-					/>
 					<link rel="preconnect" href="https://images.prismic.io" />
 				</Head>
 				<body>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,19 +1,122 @@
-import { track } from '@vercel/analytics';
-import dynamic from "next/dynamic";
+import * as prismic from "@prismicio/client";
+import { track } from "@vercel/analytics";
 import Head from "next/head";
 
 import FancyLink from "components/FancyLink";
-import SubscribeFull from "components/SubscribeFull";
+import HomeCategoryCarousels from "components/HomeCategoryCarousel";
+import { HOME_CAROUSEL_CATEGORIES } from "helpers/homeCarouselCategories";
+import { getTagDocumentBySlug } from "helpers/getTagDocumentBySlug";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import bigIdeasLittlePicturesCoverTransparentImage from "../images/big-ideas-little-pictures-cover-transparent.png";
 import styles from "./index.module.css";
 
+const SubscribeFullPlaceholder = () => (
+	<div
+		className="container mx-auto px-4 sm:px-6 lg:px-8 flex justify-center"
+		id="substack-subscribe-strip"
+	>
+		<div
+			aria-hidden="true"
+			style={{
+				width: 480,
+				height: 320,
+				maxWidth: "100%",
+				border: "1px solid #EEE",
+				background: "white",
+			}}
+		/>
+	</div>
+);
+
+const SubscribeFull = dynamic(() => import("components/SubscribeFull"), {
+	ssr: false,
+	loading: SubscribeFullPlaceholder,
+});
+
 import { client } from "services/prismic";
 
-const Sketchplanation = dynamic(() => import("../components/Sketchplanation"));
+const SKETCH_CAROUSEL_FETCH = [
+	"sketchplanation.title",
+	"sketchplanation.image",
+	"sketchplanation.published_at",
+];
 
-const Home = ({ sketchplanations }) => {
+const mapSketchForCarousel = (doc) => ({
+	uid: doc.uid,
+	title: doc.data.title,
+	image: doc.data.image,
+	publishedAt: doc.data.published_at ?? null,
+});
+
+const Home = ({ carouselRows }) => {
+	const bookSection = (
+		<section className={styles.section} aria-label="Book promotion" id="big-ideas-little-pictures-strip">
+			<div className="flex flex-col md:flex-row items-center gap-8 md:gap-12 mb-12">
+				<div className="w-full md:w-1/2 relative">
+					<div className={styles.bookSection}>
+						<Link
+							href="/big-ideas-little-pictures"
+							className="block"
+							onClick={() => {
+								track('Book-page-link', { location: 'home-book-image' });
+							}}
+							aria-label="View Big Ideas Little Pictures book details - 5-star rated on Amazon"
+						>
+							<Image
+								src={bigIdeasLittlePicturesCoverTransparentImage}
+								alt="Big Ideas Little Pictures Book"
+								className={styles.bookImage}
+								placeholder="blur"
+							/>
+							<div className={styles.quoteCircle}>
+								<div className={styles.quoteText}>
+									<p className="font-semibold">
+										This is such<br />
+										a cool book.<br />
+										<span className={styles.quoteAttribution}>— Bill Gates</span>
+									</p>
+								</div>
+							</div>
+						</Link>
+					</div>
+				</div>
+				<div className="w-full md:w-1/2 prose">
+					<Link
+						href="/big-ideas-little-pictures"
+						className="no-underline hover:no-underline"
+						onClick={() => {
+							track('Book-page-link', { location: 'home-book-text' });
+						}}
+					>
+						<h2 className="mt-2 sm:mt-6 hover:text-blue">In a Book: Big Ideas Little Pictures</h2>
+					</Link>
+					<div>
+						<p className="font-bold text-xl">
+							5-star rated on Amazon!
+						</p>
+						<p>
+							Absorb big ideas with crystal-clear understanding through this collection of 135 visual explanations.
+							Including 24 exclusive new sketches and enhanced versions of classic favourites,
+							each page shares life-improving ideas through beautifully simple illustrations.
+						</p>
+						<p>Perfect for curious minds and visual learners alike.</p>
+						<Link
+							href="/big-ideas-little-pictures"
+							className="btn-primary inline-block px-8"
+							onClick={() => {
+								track('Book-page-link', { location: 'home-book-text-button' });
+							}}
+						>
+							See inside the book
+						</Link>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+
 	return (
 		<>
 			<Head>
@@ -77,129 +180,25 @@ const Home = ({ sketchplanations }) => {
 				</div>
 			</div>
 
-			<div className="container mx-auto px-4 sm:px-6 lg:px-8 flex justify-center" id="substack-subscribe-strip">
-				<SubscribeFull />
-			</div>
-
-			<section className={styles.section} aria-label="Book promotion" id="big-ideas-little-pictures-strip">
-				<div className="flex flex-col md:flex-row items-center gap-8 md:gap-12 mb-12">
-					<div className="w-full md:w-1/2 relative">
-						<div className={styles.bookSection}>
-							<Link 
-								href="/big-ideas-little-pictures" 
-								className="block"
-								onClick={() => {
-									track('Book-page-link', { location: 'home-book-image' });
-								}}
-								aria-label="View Big Ideas Little Pictures book details - 5-star rated on Amazon"
-							>
-								<Image 
-									src={bigIdeasLittlePicturesCoverTransparentImage} 
-									alt="Big Ideas Little Pictures Book" 
-									className={styles.bookImage}
-									placeholder="blur"
-								/>
-								<div className={styles.quoteCircle}>
-									<div className={styles.quoteText}>
-										<p className="font-semibold">
-											This is such<br />
-											a cool book.<br />
-											<span className={styles.quoteAttribution}>— Bill Gates</span>
-										</p>
-									</div>
-								</div>
-							</Link>
-						</div>
-					</div>
-					<div className="w-full md:w-1/2 prose">
-						<Link
-							href="/big-ideas-little-pictures"
-							className="no-underline hover:no-underline"
-							onClick={() => {
-								track('Book-page-link', { location: 'home-book-text' });
-							}}
-						>
-							<h2 className="mt-2 sm:mt-6 hover:text-blue">In a Book: Big Ideas Little Pictures</h2>
-						</Link>
-						<div>
-							<p className="font-bold text-xl">
-								5-star rated on Amazon!
-							</p>
-							<p>
-								Absorb big ideas with crystal-clear understanding through this collection of 135 visual explanations.
-								Including 24 exclusive new sketches and enhanced versions of classic favourites,
-								each page shares life-improving ideas through beautifully simple illustrations.
-							</p>
-							<p>Perfect for curious minds and visual learners alike.</p>
-							<Link
-								href="/big-ideas-little-pictures"
-								className="btn-primary inline-block px-8"
-								onClick={() => {
-									track('Book-page-link', { location: 'home-book-text-button' });
-								}}
-							>
-								See inside the book
-							</Link>
-						</div>
-					</div>
-				</div>
-			</section>
+			<SubscribeFull />
 
 			<section className={styles.section} aria-label="About information" id="about-strip">
-				<div className="flex flex-col md:flex-row items-start mb-12 prose max-w-none">
-					<div className="w-full md:w-1/2">
-						<div className="px-0 sm:px-12 lg:px-24">
-							<h2>Hi, I&apos;m Jono 👋</h2>
-							<p>
-								I&apos;m an author and illustrator creating one of the world&apos;s largest libraries of hand-drawn sketches explaining the world—sketch-by-sketch.
-							</p>
-							<p>
-								Sketchplanations have been shared millions of times and used in books, articles, classrooms, and more. <FancyLink href="/about">Learn more about the project</FancyLink>, <FancyLink href="/search">search for a sketch you like</FancyLink>, or see recent sketches below.
-							</p>
-						</div>
-					</div>
-					<div className="w-full md:w-1/2">
-						<div className="px-0 sm:px-12 lg:px-24">
-							<h3>Explore sketches for:</h3>
-							<ul className="columns-1 sm:columns-2 gap-x-8 list-disc ml-4 [&>li]:mt-[0.25em] [&>li:first-child]:mt-0">
-								<li><FancyLink href="/categories/learning">Teachers</FancyLink></li>
-								<li><FancyLink href="/categories/management">Managers & Leaders</FancyLink></li>
-								<li><FancyLink href="/categories/writing">Writers</FancyLink></li>
-								<li><FancyLink href="/categories/software">Developers</FancyLink></li>
-								<li><FancyLink href="/categories/entrepreneurship">Entrepreneurs</FancyLink></li>
-								<li><FancyLink href="/categories/product-management">Product managers</FancyLink></li>
-								<li><FancyLink href="/categories/parenting">Parents</FancyLink></li>
-								<li><FancyLink href="/categories/data">Data scientists</FancyLink></li>
-								<li><FancyLink href="/categories/marketing">Marketers</FancyLink></li>
-								<li><FancyLink href="/categories/design">Designers</FancyLink></li>
-								<li><FancyLink href="/categories">And loads more...</FancyLink></li>
-							</ul>
-						</div>
-					</div>
+				<div className="prose max-w-none px-0 sm:px-12 lg:px-24 mb-12">
+					<h2>Hi, I&apos;m Jono 👋</h2>
+					<p>
+						I&apos;m an author and illustrator creating one of the world&apos;s largest libraries of hand-drawn sketches explaining the world—sketch-by-sketch.
+					</p>
+					<p>
+						Sketchplanations have been shared millions of times and used in books, articles, classrooms, and more. <FancyLink href="/about">Learn more about the project</FancyLink>, <FancyLink href="/search">search for a sketch you like</FancyLink>, or browse by topic below.
+					</p>
 				</div>
 			</section>
 
-			<div className="container mx-auto px-4 sm:px-6 lg:px-8 mb-8 mt-12 sm:mt-16 lg:mt-20">
-				<h2 className="prose prose-xl mx-auto text-center">Recent sketches</h2>
-			</div>
-
-			<div className={styles.sketchplanations} id="recent-sketches">
-				{sketchplanations.results.map((sketchplanation, index) => (
-					<Sketchplanation
-						key={sketchplanation.uid}
-						sketchplanation={sketchplanation}
-						priority={index === 0}
-					/>
-				))}
+			<div className="mt-4 sm:mt-8">
+				<HomeCategoryCarousels rows={carouselRows} interlude={bookSection} />
 			</div>
 
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8 my-12 flex flex-col items-center" id="see-more-strip">
-				<Link
-					href="/archive"
-					className="btn-primary w-full max-w-96 inline-block text-center py-2 px-4 mb-4"
-				>
-					See more
-				</Link>
 				<div className="text-center mt-4 mb-8">
 					<FancyLink href="/search" className={styles.footerLink}>
 						Search
@@ -233,13 +232,55 @@ const Home = ({ sketchplanations }) => {
 	);
 };
 
-export const getServerSideProps = async () => {
-	const sketchplanations = await client.getByType("sketchplanation", {
+export const getStaticProps = async () => {
+	const recent = await client.getByType("sketchplanation", {
 		orderings: [{ field: "my.sketchplanation.published_at", direction: "desc" }],
-		pageSize: 6,
+		pageSize: 20,
+		fetch: SKETCH_CAROUSEL_FETCH,
 	});
 
-	return { props: { sketchplanations } };
+	const categoryRows = await Promise.all(
+		HOME_CAROUSEL_CATEGORIES.map(async ({ slug, label }) => {
+			const tagDoc = await getTagDocumentBySlug(slug);
+			if (!tagDoc) return null;
+
+			const result = await client.getByType("sketchplanation", {
+				filters: [
+					prismic.filter.at("document.type", "sketchplanation"),
+					prismic.filter.at("my.sketchplanation.tags.tag", tagDoc.id),
+				],
+				orderings: [
+					{ field: "my.sketchplanation.published_at", direction: "desc" },
+				],
+				pageSize: 20,
+				fetch: SKETCH_CAROUSEL_FETCH,
+			});
+
+			if (result.results.length === 0) return null;
+
+			return {
+				kind: "category",
+				label,
+				slug,
+				viewAllHref: `/categories/${slug}`,
+				sketches: result.results.map(mapSketchForCarousel),
+			};
+		}),
+	);
+
+	const carouselRows = [];
+	if (recent.results.length > 0) {
+		carouselRows.push({
+			kind: "recent",
+			label: "Recent sketches",
+			slug: null,
+			viewAllHref: "/archive",
+			sketches: recent.results.map(mapSketchForCarousel),
+		});
+	}
+	carouselRows.push(...categoryRows.filter(Boolean));
+
+	return { props: { carouselRows } };
 };
 
 export default Home;


### PR DESCRIPTION
Make the homepage more enticing to see what's in the archive.

Introduces a Recent sketches carousel (links to /archive) followed by per-category carousels for audience and topic tags, separated by the Big Ideas Little Pictures book section. Carousels are swipeable on mobile and reveal arrows on hover on desktop, with intent-based prefetching, lazy-mounted below-fold rows, and analytics events.

Switches the homepage to getStaticProps, defers the Substack widget via next/dynamic, defers the search initial-results fetch to idle, trims unused font preconnects, tunes next/image sizes, and hides the footer "Explore more" block on the homepage to avoid duplication.

Sample:
<img width="1273" height="757" alt="image" src="https://github.com/user-attachments/assets/e8c081fb-c6b6-4a38-8a91-333f904f3179" />
