### PR TITLE
Allow pinch and zoom of images in lightbox

### DIFF
--- a/components/HomeCategoryCarousel.js
+++ b/components/HomeCategoryCarousel.js
@@ -278,7 +278,7 @@ function HomeCategoryCarouselRow({
 								onClick={() =>
 									track("homepage_carousel_sketch_click", {
 										category: categoryLabel,
-										sketch_title: sketch.title,
+										sketch: sketch.title,
 									})
 								}
 							>

--- a/components/SketchplanationImage.js
+++ b/components/SketchplanationImage.js
@@ -1,7 +1,8 @@
 import { PrismicNextImage } from "@prismicio/next";
-import { AnimatePresence, motion } from "framer-motion";
+import { track } from "@vercel/analytics";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { debounce } from "lodash";
-import { LoaderCircle } from "lucide-react";
+import { LoaderCircle, X } from "lucide-react";
 import {
 	useCallback,
 	useContext,
@@ -11,6 +12,7 @@ import {
 	useState,
 } from "react";
 import { Dialog, Modal, ModalOverlay } from "react-aria-components";
+import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 
 const MotionModal = motion.create(Modal);
 // const MotionDialog = motion.create(Dialog);
@@ -22,27 +24,55 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 
 	const { setDecorationHidden } = useContext(Context);
 
+	const shouldReduceMotion = useReducedMotion();
+	const zoomAnimationTime = shouldReduceMotion ? 0 : 200;
+
 	const imageRef = useRef(null);
+	const transformRef = useRef(null);
+	const wasPanningRef = useRef(false);
+	const tapTimerRef = useRef(null);
 
 	const [isOpen, setIsOpen] = useState(false);
 	const [initialImageRect, setInitialImageRect] = useState({});
 	const [isOpening, setIsOpening] = useState(false);
 	const [isClosing, setIsClosing] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
+	const [isZoomed, setIsZoomed] = useState(false);
 
 	const open = () => {
 		setIsOpening(true);
 		setIsOpen(true);
 		setDecorationHidden(true);
 		if (!isLoading) setIsLoading(true);
+		track("lightbox_open", { sketch: title });
 	};
 
 	const close = useCallback(() => {
 		if (isOpening || !isOpen) return;
 
+		transformRef.current?.resetTransform(0);
+		setIsZoomed(false);
 		setIsClosing(true);
 		setIsOpen(false);
 	}, [isOpen, isOpening]);
+
+	const handleImageTap = useCallback(() => {
+		if (wasPanningRef.current) return;
+		if (tapTimerRef.current) {
+			clearTimeout(tapTimerRef.current);
+			tapTimerRef.current = null;
+			return;
+		}
+		tapTimerRef.current = setTimeout(() => {
+			tapTimerRef.current = null;
+			const scale = transformRef.current?.state?.scale ?? 1;
+			if (scale <= 1) {
+				close();
+			} else {
+				transformRef.current?.resetTransform(zoomAnimationTime);
+			}
+		}, 250);
+	}, [close, zoomAnimationTime]);
 
 	const getInitialImageDimensions = useCallback(() => {
 		if (!imageRef.current) return;
@@ -227,21 +257,71 @@ const SketchplanationImage = ({ image, title, priority = false, children }) => {
 					<Dialog
 						ref={dialog}
 						className="w-full h-full"
+						aria-label={`${title} - zoomable image`}
 					>
-						<PrismicNextImage
-							field={imageWithAlt}
-							className="object-contain cursor-zoom-out"
-							sizes="calc(100w - 3rem)"
-							fill={true}
-							onClick={close}
-							priority
-							onLoad={() => setIsLoading(false)}
-							imgixParams={imgixParams}
-							quality={quality}
-						/>
+						<TransformWrapper
+							ref={transformRef}
+							minScale={1}
+							maxScale={3}
+							initialScale={1}
+							centerOnInit
+							limitToBounds
+							doubleClick={{ mode: "toggle", step: 2, animationTime: zoomAnimationTime }}
+							wheel={{ step: 0.08, smoothStep: 0.003 }}
+							onTransform={(_ref, state) => {
+								setIsZoomed(state.scale > 1.001);
+							}}
+							onPanningStart={() => {
+								wasPanningRef.current = false;
+							}}
+							onPanning={() => {
+								wasPanningRef.current = true;
+							}}
+							onPanningStop={() => {
+								setTimeout(() => {
+									wasPanningRef.current = false;
+								}, 50);
+							}}
+						>
+							<TransformComponent
+								wrapperStyle={{ width: "100%", height: "100%" }}
+								contentStyle={{
+									width: "100%",
+									height: "100%",
+									touchAction: "none",
+								}}
+							>
+								<div
+									role="presentation"
+									className={`relative w-full h-full ${isZoomed ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-out"}`}
+									onClick={handleImageTap}
+								>
+									<PrismicNextImage
+										field={imageWithAlt}
+										className="object-contain pointer-events-none"
+										sizes="calc(100w - 3rem)"
+										fill={true}
+										priority
+										onLoad={() => setIsLoading(false)}
+										imgixParams={imgixParams}
+										quality={quality}
+									/>
+								</div>
+							</TransformComponent>
+						</TransformWrapper>
 					</Dialog>
+					{isOpen && !isLoading && (
+						<button
+							type="button"
+							onClick={close}
+							aria-label="Close"
+							className="fixed z-30 top-3 right-3 flex items-center justify-center w-10 h-10 rounded-full bg-black/50 text-white backdrop-blur-sm hover:bg-black/70 transition-colors"
+						>
+							<X size={20} strokeWidth={2} />
+						</button>
+					)}
 					<AnimatePresence>
-						{isOpen && !isLoading && (
+						{isOpen && !isLoading && !isZoomed && (
 							<motion.div
 								className="fixed z-20 bottom-0 left-0 right-0 flex items-center justify-center h-14 border-t border-[rgba(255,255,255,0.05)] backdrop-blur-sm"
 								initial={{

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 import redirects from "./redirects.mjs";
 
 const nextConfig = {
+	allowedDevOrigins: ["*.trycloudflare.com"],
 	experimental: {
 		largePageDataBytes: 256 * 1000, // 128KB by default
 	},

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"react-rough-notation": "^1.0.5",
 		"react-text-loop": "^2.3.0",
 		"react-use-cookie": "^1.6.1",
+		"react-zoom-pan-pinch": "^4.0.3",
 		"shiitake": "^3.0.2",
 		"swiper": "^11.2.8",
 		"throttle-debounce": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       react-use-cookie:
         specifier: ^1.6.1
         version: 1.6.1(react@19.1.0)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       shiitake:
         specifier: ^3.0.2
         version: 3.0.2(react@19.1.0)
@@ -4047,6 +4050,13 @@ packages:
     engines: {node: '>=8', npm: '>=5'}
     peerDependencies:
       react: '>=16.8'
+
+  react-zoom-pan-pinch@4.0.3:
+    resolution: {integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -9092,6 +9102,11 @@ snapshots:
   react-use-cookie@1.6.1(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-zoom-pan-pinch@4.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 


### PR DESCRIPTION
Adds pan and zoom to the lightbox using react-zoom-pan-pinch so people can look at a sketch more closely on any device.

Interactions
- Pinch on mobile, mousewheel or trackpad on desktop (gentler than defaults: step 0.08, smoothStep 0.003).
- Double-tap / double-click toggles between fit (1x) and 2x, capped at a 3x maximum.
- Single tap / click at fit: closes the lightbox.
- Single tap / click while zoomed: resets back to fit.
- Pan the image by dragging while zoomed; panning never closes the lightbox or resets zoom.
- CTA bar hides while zoomed and reappears on return to fit.
- New top-right close button (X) alongside the existing Escape / Enter / Space / backdrop dismissal.

Accessibility & motion
- aria-label on the zoomable dialog and close button.
- role="presentation" on the click-handling wrapper so keyboard users rely on the close button and Escape, which are already focus-trapped by react-aria.
- Respects prefers-reduced-motion: zoom animations run instantly for users who opt out.
- Close button contrast raised slightly for readability over bright imagery.

Analytics
- Tracks a `lightbox_open` Vercel Analytics event with the sketch title, matching the `sketch: <title>` convention used elsewhere.
- Normalises the homepage carousel's `homepage_carousel_sketch_click` event to use `sketch` instead of `sketch_title` for consistency.

Also allows *.trycloudflare.com as a dev origin in next.config.mjs for tunnel-based mobile testing (dev-only, no production effect).