### PR TITLE
Remove new tab opening on homepage (#695)

### DIFF
--- a/components/HomeCategoryCarousel.js
+++ b/components/HomeCategoryCarousel.js
@@ -269,8 +269,6 @@ function HomeCategoryCarouselRow({
 								key={sketch.uid}
 								href={sketchHref}
 								className={styles.card}
-								target="_blank"
-								rel="noopener"
 								prefetch={prefetchCards ? undefined : false}
 								onMouseEnter={prefetchOnIntent}
 								onFocus={prefetchOnIntent}
@@ -314,7 +312,6 @@ function HomeCategoryCarouselRow({
 										{humanizePublishedDate(sketch.publishedAt)}
 									</time>
 								)}
-								<span className="sr-only"> (opens in new tab)</span>
 							</Link>
 						);
 					})}


### PR DESCRIPTION
## Summary

- Homepage category carousel sketch links now open in the same tab instead of a new tab
- Removes `target="_blank"`, `rel="noopener"`, and the “opens in new tab” screen-reader hint from carousel cards

Closes #695

## Test plan

- [ ] Open the homepage on mobile (or narrow viewport)
- [ ] Tap a sketch in any carousel — should navigate in the same tab
- [ ] Confirm “View all” category links still work as before
- [ ] Confirm external links in the header/footer still open in new tabs where expected


Made with [Cursor](https://cursor.com)