### PR TITLE
Track search queries in Vercel Analytics

### DIFF
--- a/.cursor/rules/github-workflow.mdc
+++ b/.cursor/rules/github-workflow.mdc
@@ -23,6 +23,7 @@ Keep issue titles concise enough to slug cleanly (under ~40 characters of slug t
 
 - Stay on the issue branch unless the user asks otherwise.
 - Do not commit until the user asks to complete or finish the work.
+- Improvements to this workflow doc (e.g. tooling, conventions) may be committed alongside other work on the same branch when they come up.
 
 ## Complete work
 
@@ -38,7 +39,7 @@ Review all changes before staging or committing. Fix issues found; do not commit
 - **Performance**: Consider impact on page load, bundle size, images, fonts, and runtime work — roughly what a Chrome Lighthouse audit would flag. Flag regressions and fix or justify them.
 - **Build**: Consider whether build time will increase substantially (`npm run build` when in doubt). If it does, ensure the trade-off is worthwhile.
 - **SEO**: Check titles, meta descriptions, headings, structured data, canonical URLs, and link behaviour. Ensure nothing is negatively affected.
-- **Tests**: Add coverage where appropriate — meaningful cases, not exhaustive edge-case sprawl. Run `npm test` and ensure tests pass.
+- **Tests**: Add Vitest coverage where appropriate — meaningful cases, not exhaustive edge-case sprawl. Run `npm test` (Vitest) and ensure tests pass.
 - **Removals**: Confirm deleted code only removes deliberately abandoned functionality. If a feature appears unused and removal wasn't in the brief, ask before removing it.
 - **Best practice**: Check accessibility, error handling, security, and consistency with surrounding code.
 
@@ -63,5 +64,5 @@ Draft the commit message and PR description from the actual diff and conversatio
 - Project: https://github.com/users/jonohey/projects/3 (project #3)
 - Default branch: `master`
 - Branch pattern: `{issue-number}-{slug}` (e.g. `701-improve-header-nav`). Slugs must read as a complete phrase — the script truncates at the last hyphen within 40 characters, never mid-word.
-- Tests: `npm test`
+- Tests: `npm test` (Vitest)
 - Build: `npm run build`

--- a/.cursor/rules/github-workflow.mdc
+++ b/.cursor/rules/github-workflow.mdc
@@ -17,6 +17,8 @@ When the user wants to start new work (e.g. "Start work on …", "New ticket for
 
 Derive the title from the user's message. Use their detail as the issue body when provided; otherwise the script stub is fine.
 
+Keep issue titles concise enough to slug cleanly (under ~40 characters of slug text is ideal). The script truncates long slugs at a word boundary, never mid-word.
+
 ## While working
 
 - Stay on the issue branch unless the user asks otherwise.
@@ -60,6 +62,6 @@ Draft the commit message and PR description from the actual diff and conversatio
 - Repo: `jonohey/sketchplanations`
 - Project: https://github.com/users/jonohey/projects/3 (project #3)
 - Default branch: `master`
-- Branch pattern: `{issue-number}-{slug}` (e.g. `701-improve-header-nav`)
+- Branch pattern: `{issue-number}-{slug}` (e.g. `701-improve-header-nav`). Slugs must read as a complete phrase — the script truncates at the last hyphen within 40 characters, never mid-word.
 - Tests: `npm test`
 - Build: `npm run build`

--- a/hooks/useSearch.js
+++ b/hooks/useSearch.js
@@ -170,11 +170,14 @@ const useSearch = () => {
 
 		prevTrackedQuery.current = analyticsSearchQuery;
 
+		const trimmedQuery = analyticsSearchQuery.trim();
 		const { sketches } = search(analyticsSearchQuery);
-		track("Search", {
-			query: analyticsSearchQuery.trim(),
-			resultCount: sketches.length,
-		});
+
+		if (sketches.length > 0) {
+			track("Search", { query: trimmedQuery });
+		} else {
+			track("Search_no_results", { query: trimmedQuery });
+		}
 	}, [analyticsSearchQuery, indexReady, search]);
 
 	useEffect(() => {

--- a/hooks/useSearch.js
+++ b/hooks/useSearch.js
@@ -16,6 +16,10 @@ const ANALYTICS_DEBOUNCE_MS = 1500;
 const isSearchableQuery = (value) =>
 	isPresent(value) && value.trim().length >= MIN_QUERY_LENGTH;
 
+// useSearch is mounted twice on /search (page + SearchResults); share dedup so
+// analytics fires once per settled query, not once per hook instance.
+const lastTrackedAnalyticsQuery = { current: null };
+
 const fetchIntialResults = async () => {
 	const response = await fetch("/api/initial-search-results");
 	const results = await response.json();
@@ -40,7 +44,6 @@ const useSearch = () => {
 	const { ready: indexReady, search } = useSearchIndex();
 
 	const prevSearchQuery = useRef(null);
-	const prevTrackedQuery = useRef(null);
 	const debouncedSearchQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
 	const analyticsSearchQuery = useDebouncedValue(query, ANALYTICS_DEBOUNCE_MS);
 
@@ -156,7 +159,7 @@ const useSearch = () => {
 
 	useEffect(() => {
 		if (!isSearchableQuery(analyticsSearchQuery)) {
-			prevTrackedQuery.current = null;
+			lastTrackedAnalyticsQuery.current = null;
 			return undefined;
 		}
 
@@ -164,11 +167,11 @@ const useSearch = () => {
 			return undefined;
 		}
 
-		if (prevTrackedQuery.current === analyticsSearchQuery) {
+		if (lastTrackedAnalyticsQuery.current === analyticsSearchQuery) {
 			return undefined;
 		}
 
-		prevTrackedQuery.current = analyticsSearchQuery;
+		lastTrackedAnalyticsQuery.current = analyticsSearchQuery;
 
 		const trimmedQuery = analyticsSearchQuery.trim();
 		const { sketches } = search(analyticsSearchQuery);

--- a/hooks/useSearch.js
+++ b/hooks/useSearch.js
@@ -9,6 +9,9 @@ import useSearchIndex from "./useSearchIndex";
 
 // A single character is never a meaningful search, so we don't run one.
 const MIN_QUERY_LENGTH = 2;
+const SEARCH_DEBOUNCE_MS = 300;
+// Wait longer before analytics so slow typing doesn't emit partial queries.
+const ANALYTICS_DEBOUNCE_MS = 1500;
 
 const isSearchableQuery = (value) =>
 	isPresent(value) && value.trim().length >= MIN_QUERY_LENGTH;
@@ -37,7 +40,9 @@ const useSearch = () => {
 	const { ready: indexReady, search } = useSearchIndex();
 
 	const prevSearchQuery = useRef(null);
-	const debouncedSearchQuery = useDebouncedValue(query, 300);
+	const prevTrackedQuery = useRef(null);
+	const debouncedSearchQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
+	const analyticsSearchQuery = useDebouncedValue(query, ANALYTICS_DEBOUNCE_MS);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -145,15 +150,32 @@ const useSearch = () => {
 			setMatchQuality(quality);
 			setCorrectedLabel(label);
 			setHasExactCategoryMatch(exactCategory);
-
-			// Fires once per debounced query (2+ chars), not on every keystroke.
-			track("Search", {
-				query: searchQuery.trim(),
-				resultCount: sketches.length,
-			});
 		},
 		[search],
 	);
+
+	useEffect(() => {
+		if (!isSearchableQuery(analyticsSearchQuery)) {
+			prevTrackedQuery.current = null;
+			return undefined;
+		}
+
+		if (!indexReady) {
+			return undefined;
+		}
+
+		if (prevTrackedQuery.current === analyticsSearchQuery) {
+			return undefined;
+		}
+
+		prevTrackedQuery.current = analyticsSearchQuery;
+
+		const { sketches } = search(analyticsSearchQuery);
+		track("Search", {
+			query: analyticsSearchQuery.trim(),
+			resultCount: sketches.length,
+		});
+	}, [analyticsSearchQuery, indexReady, search]);
 
 	useEffect(() => {
 		if (!isSearchableQuery(debouncedSearchQuery)) {

--- a/hooks/useSearch.js
+++ b/hooks/useSearch.js
@@ -1,3 +1,4 @@
+import { track } from "@vercel/analytics";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -144,6 +145,12 @@ const useSearch = () => {
 			setMatchQuality(quality);
 			setCorrectedLabel(label);
 			setHasExactCategoryMatch(exactCategory);
+
+			// Fires once per debounced query (2+ chars), not on every keystroke.
+			track("Search", {
+				query: searchQuery.trim(),
+				resultCount: sketches.length,
+			});
 		},
 		[search],
 	);

--- a/scripts/start-work.sh
+++ b/scripts/start-work.sh
@@ -28,10 +28,20 @@ if ! gh auth status 2>&1 | grep -q "read:project\|project"; then
 fi
 
 slugify() {
-  echo "$1" \
+  local slug max=40
+  slug=$(echo "$1" \
     | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
-    | cut -c1-40
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+
+  if ((${#slug} <= max)); then
+    echo "$slug"
+    return
+  fi
+
+  # Truncate at a word boundary within the limit so the slug is a complete phrase.
+  local truncated="${slug:0:max}"
+  truncated="${truncated%-}" # drop trailing hyphen when the cut landed mid-segment
+  echo "${truncated%-*}"
 }
 
 echo "Syncing latest $DEFAULT_BRANCH..."


### PR DESCRIPTION
## Summary

- Fire `Search` (with `query` only) when a settled search returns sketch matches.
- Fire `Search_no_results` (with `query` only) when a settled search returns zero sketch matches — for spotting content gaps.
- Analytics use a 1.5s debounce (separate from the 300ms search debounce) so slow typing doesn't emit partial queries.
- Only track searches of 2+ characters, once per distinct settled query.
- Deduplicate analytics across the two `useSearch` mounts on `/search` (page + `SearchResults`) so each search fires one event, not two.
- Fix `start-work.sh` branch slug truncation at word boundaries; Cursor workflow rules updated.

## Why

Vercel Web Analytics strips query parameters from page views, so `/search?q=…` terms were invisible. Custom events make search terms visible for content planning. A separate `Search_no_results` event is easier to filter and CSV-export than a `resultCount` property, which doesn't appear alongside queries in the dashboard.

## Test plan

- [x] `npm test` — 56 tests pass
- [ ] Search a term with sketch matches — confirm one `Search` event with readable `query` in Vercel Analytics (Preview environment)
- [ ] Search a term with no sketch matches — confirm one `Search_no_results` event (not `Search`)
- [ ] Type a multi-word query slowly — confirm only one event fires after ~1.5s pause, not one per prefix
- [ ] Confirm Total count is 1 per search (not 2) — previously inflated because `useSearch` ran twice on the search page
- [ ] Export `Search_no_results` CSV grouped by `query` — confirm useful list of missed searches

Closes #703