### PR TITLE
Update behind Dependabot patch/minor PRs before auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
       - uses: dependabot/fetch-metadata@v2
         id: metadata
 
+      - name: Update branch if behind base
+        if: |
+          github.event.pull_request.mergeable_state == 'behind' && (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          )
+        run: gh api -X PUT "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/update-branch"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge patch and minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
## Summary

- Adds an `update-branch` step to the Dependabot auto-merge job when a patch or minor PR is behind `main`
- Runs before enabling auto-merge, so branch protection’s “up-to-date branch” requirement no longer blocks safe Dependabot PRs (e.g. #711)

## Why

Auto-merge was enabled and CI was green, but PRs stayed open with “This branch is out-of-date with the base branch”. The ruleset requires an up-to-date branch before merge.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, re-run CI on a stuck Dependabot PR (or wait for the next weekly batch) and confirm the branch updates automatically, checks re-run, and auto-merge completes

## Note on #711

Merging this PR alone will **not** immediately unblock #711 — that PR needs a fresh CI run using the updated workflow while it is still behind. After merge, either **Re-run all jobs** on #711 or click **Update branch** once; the workflow will handle it from there on future PRs.

Closes #715

Made with [Cursor](https://cursor.com)