### PR TITLE
Fix dependabot major-update workflow label step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
       - uses: dependabot/fetch-metadata@v2
@@ -57,9 +58,10 @@ jobs:
       - name: Flag major updates for manual review
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
-          gh label create "breaking-change" \
-            --description "Major dependency update requiring manual review" \
-            --color "d93f0b" 2>/dev/null || true
+          gh label list --json name --jq '.[].name' | grep -qx breaking-change || \
+            gh label create "breaking-change" \
+              --description "Major dependency update requiring manual review" \
+              --color "d93f0b"
           gh pr edit "$PR_URL" --add-label "breaking-change"
           gh pr comment "$PR_URL" --body "Major version bump — needs manual review before merge."
         env:


### PR DESCRIPTION
## Summary

- Adds `issues: write` to the `dependabot-auto-merge` job so it can create repository labels
- Creates the `breaking-change` label only when missing, instead of swallowing create failures

This fixes the CI failure seen on major Dependabot PRs (e.g. #714), where `gh pr edit --add-label breaking-change` failed because label creation had no permission and was silently ignored.

## Test plan

- [ ] Merge this PR
- [ ] On the next semver-major Dependabot PR, confirm `dependabot-auto-merge` passes and the PR gets the `breaking-change` label plus review comment
- [ ] Confirm patch/minor Dependabot PRs still auto-merge after tests pass

Closes #722

Made with [Cursor](https://cursor.com)