### PR TITLE
Upgrade swiper to fix critical prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"react-zoom-pan-pinch": "^4.0.3",
 		"shiitake": "^3.0.2",
 		"stemmer": "^2.0.1",
-		"swiper": "^11.2.8",
+		"swiper": "^12.2.0",
 		"throttle-debounce": "^5.0.2",
 		"vanilla-cookieconsent": "3.1.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       swiper:
-        specifier: ^11.2.8
-        version: 11.2.8
+        specifier: ^12.2.0
+        version: 12.2.0
       throttle-debounce:
         specifier: ^5.0.2
         version: 5.0.2
@@ -3620,8 +3620,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swiper@11.2.8:
-    resolution: {integrity: sha512-S5FVf6zWynPWooi7pJ7lZhSUe2snTzqLuUzbd5h5PHUOhzgvW0bLKBd2wv0ixn6/5o9vwc/IkQT74CRcLJQzeg==}
+  swiper@12.2.0:
+    resolution: {integrity: sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==}
     engines: {node: '>= 4.7.0'}
 
   synckit@0.11.13:
@@ -7525,7 +7525,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swiper@11.2.8: {}
+  swiper@12.2.0: {}
 
   synckit@0.11.13:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrades `swiper` from 11.2.8 to 12.2.0 to address CVE-2026-27212, a critical prototype pollution vulnerability (CVSS 9.4) flagged by Dependabot
- No component changes required — existing usage in `SketchplanationsStack` and `TaggedSketchplanations` is compatible with v12

## Test plan

- [x] `npm test` — 56 tests passed
- [x] `npm run build` — compiles and generates all static pages
- [x] On a sketchplanation page (e.g. `/wabi-sabi`), verify **Keep exploring** card stack: prev/next buttons, drag/swipe, slide shadows
- [x] On the same page, verify **More on these topics** carousel: tag tabs, horizontal scroll, mousewheel on desktop

Closes #726

Made with [Cursor](https://cursor.com)